### PR TITLE
Fix readonly middleware array should not return type error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Updated `exports` field to workaround [TypeScript resolution bug](https://github.com/microsoft/TypeScript/issues/50762), by [@compulim](https://github.com/compulim), in PR [#20](https://github.com/compulim/react-chain-of-responsibility/pull/20)
+- Fixed [#32](https://github.com/compulim/react-chain-of-responsibility/issues/32), readonly middleware array should not return type error, by [@compulim](https://github.com/compulim), in PR [#XX](https://github.com/compulim/react-chain-of-responsibility/pull/XX)
+
 ### Changed
 
 - Added type-checking for test, by [@compulim](https://github.com/compulim), in PR [#20](https://github.com/compulim/react-chain-of-responsibility/pull/20)
@@ -18,10 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       - [`react-dom@18.2.0`](https://npmjs.com/package/react-dom)
       - [`react-test-renderer@18.2.0`](https://npmjs.com/package/react-test-renderer)
       - [`react@18.2.0`](https://npmjs.com/package/react)
-
-### Fixed
-
-- Updated `exports` field to workaround [TypeScript resolution bug](https://github.com/microsoft/TypeScript/issues/50762), by [@compulim](https://github.com/compulim), in PR [#20](https://github.com/compulim/react-chain-of-responsibility/pull/20)
 
 ## [0.0.1] - 2023-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated `exports` field to workaround [TypeScript resolution bug](https://github.com/microsoft/TypeScript/issues/50762), by [@compulim](https://github.com/compulim), in PR [#20](https://github.com/compulim/react-chain-of-responsibility/pull/20)
-- Fixed [#32](https://github.com/compulim/react-chain-of-responsibility/issues/32), readonly middleware array should not return type error, by [@compulim](https://github.com/compulim), in PR [#XX](https://github.com/compulim/react-chain-of-responsibility/pull/XX)
+- Fixed [#32](https://github.com/compulim/react-chain-of-responsibility/issues/32), readonly middleware array should not return type error, by [@compulim](https://github.com/compulim), in PR [#33](https://github.com/compulim/react-chain-of-responsibility/pull/33)
 
 ### Changed
 

--- a/packages/react-chain-of-responsibility/src/createChainOfResponsibility.middleware.readOnly.test.tsx
+++ b/packages/react-chain-of-responsibility/src/createChainOfResponsibility.middleware.readOnly.test.tsx
@@ -1,0 +1,26 @@
+/** @jest-environment jsdom */
+/// <reference types="@types/jest" />
+
+import { render } from '@testing-library/react';
+import React, { Fragment } from 'react';
+
+import createChainOfResponsibility from './createChainOfResponsibility';
+
+type Props = { children?: never };
+
+test('middleware should render readonly middleware array', () => {
+  // GIVEN: A middleware return a component that would render "Hello, World!".
+  const { Provider, Proxy } = createChainOfResponsibility<undefined, Props>();
+
+  // WHEN: Render <Proxy>.
+  const App = () => (
+    <Provider middleware={Object.freeze([() => () => () => () => <Fragment>Hello, World!</Fragment>])}>
+      <Proxy />
+    </Provider>
+  );
+
+  const result = render(<App />);
+
+  // THEN: It should render "Hello, World!".
+  expect(result.container).toHaveProperty('textContent', 'Hello, World!');
+});


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Fixed

- Fixed [#32](https://github.com/compulim/react-chain-of-responsibility/issues/32), readonly middleware array should not return type error, by [@compulim](https://github.com/compulim), in PR [#33](https://github.com/compulim/react-chain-of-responsibility/pull/33)

## Specific changes

> Please list each individual specific change in this pull request.

- Add `readonly` to props
- Clean up ESLint to eliminate immediate return in function
- Clean up unnecessary coalesces
- Add test