### PR TITLE
Relax peer dependencies of react@16.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#42](https://github.com/compulim/react-chain-of-responsibility/pull/42) and [#43](https://github.com/compulim/react-chain-of-responsibility/pull/43)
+- Relaxed peer dependencies requirements to `react@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#XX](https://github.com/compulim/react-chain-of-responsibility/pull/XX)
+- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#42](https://github.com/compulim/react-chain-of-responsibility/pull/42), [#43](https://github.com/compulim/react-chain-of-responsibility/pull/43), and [#XX](https://github.com/compulim/react-chain-of-responsibility/pull/XX)
    - Production dependencies
       - [`@babel/runtime-corejs3@7.24.1`](https://npmjs.com/package/@babel/runtime-corejs3)
    - Development dependencies
@@ -33,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       - [`eslint-plugin-react@7.34.1`](https://npmjs.com/package/eslint-plugin-react)
       - [`eslint@8.57.0`](https://npmjs.com/package/eslint)
       - [`prettier@3.2.5`](https://npmjs.com/package/prettier)
+      - [`react-wrap-with@0.1.0`](https://npmjs.com/package/react-wrap-with)
       - [`typescript@5.4.3`](https://npmjs.com/package/typescript)
 - Updated pull request validation to test against various React versions, in PR [#44](https://github.com/compulim/react-chain-of-responsibility/pull/44)
    - Moved from JSX Runtime to JSX Classic to support testing against React 16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Relaxed peer dependencies requirements to `react@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#XX](https://github.com/compulim/react-chain-of-responsibility/pull/XX)
-- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#42](https://github.com/compulim/react-chain-of-responsibility/pull/42), [#43](https://github.com/compulim/react-chain-of-responsibility/pull/43), and [#XX](https://github.com/compulim/react-chain-of-responsibility/pull/XX)
+- Relaxed peer dependencies requirements to `react@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#45](https://github.com/compulim/react-chain-of-responsibility/pull/45)
+- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#42](https://github.com/compulim/react-chain-of-responsibility/pull/42), [#43](https://github.com/compulim/react-chain-of-responsibility/pull/43), and [#45](https://github.com/compulim/react-chain-of-responsibility/pull/45)
    - Production dependencies
       - [`@babel/runtime-corejs3@7.24.1`](https://npmjs.com/package/@babel/runtime-corejs3)
    - Development dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1894,23 +1894,16 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.21.0.tgz",
-      "integrity": "sha512-TDD4UJzos3JJtM+tHX+w2Uc+KWj7GV+VKKFdMVd2Rx8sdA19hcc3P3AHFYd5LVOw+pYuSd5lICC3gm52B6Rwxw==",
-      "dev": true,
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.24.1.tgz",
+      "integrity": "sha512-T9ko/35G+Bkl+win48GduaPlhSlOjjE5s1TeiEcD+QpxlLQnoEfb/nO/T+TQqkm+ipFwORn+rB8w14iJ/uD0bg==",
       "dependencies": {
-        "core-js-pure": "^3.25.1",
-        "regenerator-runtime": "^0.13.11"
+        "core-js-pure": "^3.30.2",
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
-      "dev": true
     },
     "node_modules/@babel/template": {
       "version": "7.24.0",
@@ -9937,15 +9930,29 @@
       }
     },
     "node_modules/react-wrap-with": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/react-wrap-with/-/react-wrap-with-0.0.2.tgz",
-      "integrity": "sha512-AwXuO3EOzCkin5X0cSSaHYFhNH3uAMbfXi2jKdfmtvq1Kzt78ygBwgYiW3OAlTBTGDEOjA72CsNqZdRQ2+fIMA==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/react-wrap-with/-/react-wrap-with-0.1.0.tgz",
+      "integrity": "sha512-8+UKXYLofRBNtSfeZCM81/X0sCvJRv0/nrt42lPozrF/BF0WW2/QDoZQLKuvkMxN+i8qaGzC7mOM6z4UGwlpug==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime-corejs3": "7.21.0"
+        "@babel/runtime-corejs3": "^7.24.1",
+        "react-wrap-with": "^0.1.0",
+        "type-fest": "^4.14.0"
       },
       "peerDependencies": {
-        "react": ">=16.9.0"
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/react-wrap-with/node_modules/type-fest": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.14.0.tgz",
+      "integrity": "sha512-on5/Cw89wwqGZQu+yWO0gGMGu8VNxsaW9SB2HE8yJjllEk7IDTwnSN1dUVldYILhYPN5HzD7WAaw2cc/jBfn0Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/readdirp": {
@@ -10001,10 +10008,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -11290,7 +11296,7 @@
         "@types/react": "^18.2.21",
         "@types/react-dom": "^18.2.7",
         "esbuild": "^0.19.2",
-        "react-wrap-with": "^0.0.2",
+        "react-wrap-with": "^0.1.0",
         "typescript": "^5.2.2"
       }
     },
@@ -11316,29 +11322,18 @@
         "@types/node": "^20.11.30",
         "@types/react": "^18.2.70",
         "esbuild": "^0.20.2",
+        "escape-string-regexp": "^5.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "prettier": "^3.2.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-test-renderer": "^18.2.0",
-        "react-wrap-with": "^0.0.4",
+        "react-wrap-with": "^0.1.0",
         "typescript": "^5.4.3"
       },
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "packages/react-chain-of-responsibility/node_modules/@babel/runtime-corejs3": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.24.1.tgz",
-      "integrity": "sha512-T9ko/35G+Bkl+win48GduaPlhSlOjjE5s1TeiEcD+QpxlLQnoEfb/nO/T+TQqkm+ipFwORn+rB8w14iJ/uD0bg==",
-      "dependencies": {
-        "core-js-pure": "^3.30.2",
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "packages/react-chain-of-responsibility/node_modules/@esbuild/android-arm": {
@@ -11731,32 +11726,13 @@
         "@esbuild/win32-x64": "0.20.2"
       }
     },
-    "packages/react-chain-of-responsibility/node_modules/react-wrap-with": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/react-wrap-with/-/react-wrap-with-0.0.4.tgz",
-      "integrity": "sha512-Bpnza9Sx3/MyUyNJyYMEsXJkYZVTVPJXfKYTAXuzrM8en1MA04BCd4xS4zJEUnhAgZvKvvx5flNAlnwgOvsw1A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.22.15",
-        "react-wrap-with": "^0.0.4",
-        "type-fest": "^4.4.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0"
-      }
-    },
-    "packages/react-chain-of-responsibility/node_modules/regenerator-runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
-    },
-    "packages/react-chain-of-responsibility/node_modules/type-fest": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.4.0.tgz",
-      "integrity": "sha512-HT3RRs7sTfY22KuPQJkD/XjbTbxgP2Je5HPt6H6JEGvcjHd5Lqru75EbrP3tb4FYjNJ+DjLp+MNQTFQU0mhXNw==",
+    "packages/react-chain-of-responsibility/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "dev": true,
       "engines": {
-        "node": ">=16"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-chain-of-responsibility-root",
-  "version": "0.0.3-0",
+  "version": "0.1.0-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-chain-of-responsibility-root",
-      "version": "0.0.3-0",
+      "version": "0.1.0-0",
       "license": "MIT",
       "workspaces": [
         "packages/react-chain-of-responsibility",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chain-of-responsibility-root",
-  "version": "0.0.3-0",
+  "version": "0.1.0-0",
   "description": "",
   "private": true,
   "author": "William Wong (https://github.com/compulim)",

--- a/packages/integration-test/package.json
+++ b/packages/integration-test/package.json
@@ -20,8 +20,8 @@
   "switch:react:16": {
     "devDependencies": {
       "@types/react": "^16",
-      "react": "16.9.0",
-      "react-test-renderer": "16.9.0"
+      "react": "16.8.0",
+      "react-test-renderer": "16.8.0"
     }
   },
   "switch:react:17": {

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -25,8 +25,8 @@
       "@types/react-dom": "^16"
     },
     "dependencies": {
-      "react": "16.9.0",
-      "react-dom": "16.9.0"
+      "react": "16.8.0",
+      "react-dom": "16.8.0"
     }
   },
   "switch:react:17": {
@@ -55,7 +55,7 @@
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
     "esbuild": "^0.19.2",
-    "react-wrap-with": "^0.0.2",
+    "react-wrap-with": "^0.1.0",
     "typescript": "^5.2.2"
   },
   "dependencies": {

--- a/packages/pages/src/app/decoration/Demo.tsx
+++ b/packages/pages/src/app/decoration/Demo.tsx
@@ -24,7 +24,11 @@ const middleware: (typeof types.middleware)[] = [
 
     return Next;
   },
-  () => next => request => wrapWith(request?.has('italic') && Italic)(next(request)),
+  () => next => request => {
+    const nextValue = next(request);
+
+    return request?.has('italic') && nextValue ? wrapWith(Italic)(nextValue) : nextValue;
+  },
   () => () => () => Plain
 ];
 

--- a/packages/react-chain-of-responsibility/package.json
+++ b/packages/react-chain-of-responsibility/package.json
@@ -80,9 +80,9 @@
     "devDependencies": {
       "@testing-library/react": "^12",
       "@types/react": "^16",
-      "react": "16.9.0",
-      "react-dom": "16.9.0",
-      "react-test-renderer": "16.9.0"
+      "react": "16.8.0",
+      "react-dom": "16.8.0",
+      "react-test-renderer": "16.8.0"
     }
   },
   "switch:react:17": {
@@ -117,13 +117,14 @@
     "@types/node": "^20.11.30",
     "@types/react": "^18.2.70",
     "esbuild": "^0.20.2",
+    "escape-string-regexp": "^5.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "prettier": "^3.2.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-test-renderer": "^18.2.0",
-    "react-wrap-with": "^0.0.4",
+    "react-wrap-with": "^0.1.0",
     "typescript": "^5.4.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Changed

- Relaxed peer dependencies requirements to `react@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#45](https://github.com/compulim/react-chain-of-responsibility/pull/45)
- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#42](https://github.com/compulim/react-chain-of-responsibility/pull/42), [#43](https://github.com/compulim/react-chain-of-responsibility/pull/43), and [#45](https://github.com/compulim/react-chain-of-responsibility/pull/45)
   - Development dependencies
      - [`react-wrap-with@0.1.0`](https://npmjs.com/package/react-wrap-with)

## Specific changes

> Please list each individual specific change in this pull request.

- Run `npm version --no-git-tag-version preminor`
- Update `/packages/react-chain-of-responsibility/package.json/peerDependencies/react` to `>=16.8.0`
