### PR TITLE
Add nested provider of same chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - `import { createChainOfResponsibilityForFluentUI } from 'react-chain-of-responsibility/fluentUI'` for Fluent UI renderer function
 - Moved build tools from Babel to tsup/esbuild
 
+### Added
+
+- Support nested provider of same type, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/compulim/react-chain-of-responsibility/pull/XXX)
+   - Components will be built using middleware from `<Provider>` closer to the `<Proxy>` and fallback to those farther
+
 ### Changed
 
 - Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#49](https://github.com/compulim/react-chain-of-responsibility/pull/49), [#58](https://github.com/compulim/react-chain-of-responsibility/pull/58), and [#63](https://github.com/compulim/react-chain-of-responsibility/pull/63)

--- a/README.md
+++ b/README.md
@@ -190,6 +190,34 @@ type UseBuildComponentCallback<Request, Props> = (
 
 The `fallbackComponent` is a component which all unhandled requests will sink into.
 
+### Nesting `<Provider>`
+
+If the `<Provider>` from the same chain appears nested in the tree, the `<Proxy>` will render using the middleware from the closest `<Provider>` and fallback up the chain. The following code snippet will render "Second First".
+
+```jsx
+const { Provider, Proxy } = createChainOfResponsibility();
+
+const firstMiddleware = () => next => request => {
+  const NextComponent = next(request);
+
+  return () => <Fragment>First {NextComponent && <NextComponent />}</Fragment>;
+};
+
+const secondMiddleware = () => next => request => {
+  const NextComponent = next(request);
+
+  return () => <Fragment>Second {NextComponent && <NextComponent />}</Fragment>;
+};
+
+render(
+  <Provider middleware={[firstMiddleware]}>
+    <Provider middleware={[secondMiddleware]}>
+      <Proxy />
+    </Provider>
+  </Provider>
+);
+```
+
 ### API for Fluent UI
 
 ```ts

--- a/packages/react-chain-of-responsibility/src/createChainOfResponsibility.nested.sameProvider.test.tsx
+++ b/packages/react-chain-of-responsibility/src/createChainOfResponsibility.nested.sameProvider.test.tsx
@@ -1,0 +1,63 @@
+/** @jest-environment jsdom */
+/// <reference types="@types/jest" />
+
+import { render } from '@testing-library/react';
+import React, { Fragment } from 'react';
+
+import createChainOfResponsibility from './createChainOfResponsibility';
+
+type Props = { children?: never };
+
+test('two providers of chain of responsibility nested should render', () => {
+  // GIVEN: One chain of responsibility.
+  const { Provider, Proxy, types } = createChainOfResponsibility<undefined, Props>();
+
+  const middleware1: readonly (typeof types.middleware)[] = Object.freeze([
+    () => next => request => {
+      const Component = next(request);
+
+      return props => <Fragment>World {Component && <Component {...props} />}</Fragment>;
+    }
+  ]);
+  const middleware2: readonly (typeof types.middleware)[] = Object.freeze([
+    () => next => request => {
+      const Component = next(request);
+
+      return props => <Fragment>Hello {Component && <Component {...props} />}</Fragment>;
+    }
+  ]);
+
+  // WHEN: Render <Proxy> with same providers twice.
+  const App = ({
+    middleware1,
+    middleware2
+  }: {
+    middleware1: readonly (typeof types.middleware)[];
+    middleware2: readonly (typeof types.middleware)[];
+  }) => (
+    <Provider middleware={middleware1}>
+      <Provider middleware={middleware2}>
+        <Proxy />
+      </Provider>
+    </Provider>
+  );
+
+  const result = render(<App middleware1={middleware1} middleware2={middleware2} />);
+
+  // THEN: It should render "Hello World ".
+  expect(result.container).toHaveProperty('textContent', 'Hello World ');
+
+  // WHEN: First middleware is updated.
+  const middleware3: readonly (typeof types.middleware)[] = Object.freeze([
+    () => next => request => {
+      const Component = next(request);
+
+      return props => <Fragment>Aloha {Component && <Component {...props} />}</Fragment>;
+    }
+  ]);
+
+  result.rerender(<App middleware1={middleware3} middleware2={middleware2} />);
+
+  // THEN: It should render "Hello Aloha ".
+  expect(result.container).toHaveProperty('textContent', 'Hello Aloha ');
+});

--- a/packages/react-chain-of-responsibility/src/createChainOfResponsibility.nested.sameProvider.test.tsx
+++ b/packages/react-chain-of-responsibility/src/createChainOfResponsibility.nested.sameProvider.test.tsx
@@ -44,6 +44,8 @@ test('two providers of chain of responsibility nested should render', () => {
     }
   ]);
 
+  const FallbackComponent = () => <Fragment>End</Fragment>;
+
   // WHEN: Render <Proxy> with same providers twice.
   const App = ({
     middleware1,
@@ -55,10 +57,10 @@ test('two providers of chain of responsibility nested should render', () => {
     <Provider init={1} middleware={middleware1}>
       {middleware2 ? (
         <Provider init={2} middleware={middleware2}>
-          <Proxy />
+          <Proxy fallbackComponent={FallbackComponent} />
         </Provider>
       ) : (
-        <Proxy />
+        <Proxy fallbackComponent={FallbackComponent} />
       )}
     </Provider>
   );
@@ -66,7 +68,7 @@ test('two providers of chain of responsibility nested should render', () => {
   const result = render(<App middleware1={middleware1} middleware2={middleware2} />);
 
   // THEN: It should render "First2 Second2 Third1 ".
-  expect(result.container).toHaveProperty('textContent', 'First2 Second2 Third1 ');
+  expect(result.container).toHaveProperty('textContent', 'First2 Second2 Third1 End');
 
   // WHEN: First middleware is updated.
   const middleware3: readonly (typeof types.middleware)[] = Object.freeze([
@@ -84,11 +86,11 @@ test('two providers of chain of responsibility nested should render', () => {
   result.rerender(<App middleware1={middleware3} middleware2={middleware2} />);
 
   // THEN: It should render "First2 Second2 Fourth1 ".
-  expect(result.container).toHaveProperty('textContent', 'First2 Second2 Fourth1 ');
+  expect(result.container).toHaveProperty('textContent', 'First2 Second2 Fourth1 End');
 
   // WHEN: Second provider is removed middleware is updated.
   result.rerender(<App middleware1={middleware3} />);
 
   // THEN: It should render "Fourth1 ".
-  expect(result.container).toHaveProperty('textContent', 'Fourth1 ');
+  expect(result.container).toHaveProperty('textContent', 'Fourth1 End');
 });

--- a/packages/react-chain-of-responsibility/src/createChainOfResponsibility.tsx
+++ b/packages/react-chain-of-responsibility/src/createChainOfResponsibility.tsx
@@ -11,18 +11,21 @@ import React, {
 } from 'react';
 
 import isReactComponent from './isReactComponent';
-import applyMiddleware from './private/applyMiddleware';
+import applyMiddleware, { type Enhancer } from './private/applyMiddleware';
 import { type ComponentMiddleware } from './types';
 
-type UseBuildComponentCallbackOptions<Props> = { fallbackComponent?: ComponentType<Props> | false | null | undefined };
+type ResultComponent<Props> = ComponentType<Props> | false | null | undefined;
+
+type UseBuildComponentCallbackOptions<Props> = { fallbackComponent?: ResultComponent<Props> };
 
 type UseBuildComponentCallback<Request, Props> = (
   request: Request,
   options?: UseBuildComponentCallbackOptions<Props>
-) => ComponentType<Props> | false | null | undefined;
+) => ResultComponent<Props>;
 
 type ProviderContext<Request, Props> = {
-  useBuildComponentCallback: UseBuildComponentCallback<Request, Props>;
+  get enhancer(): Enhancer<[Request], ResultComponent<Props>> | undefined;
+  get useBuildComponentCallback(): UseBuildComponentCallback<Request, Props>;
 };
 
 type ProviderProps<Request, Props, Init> = PropsWithChildren<{
@@ -64,6 +67,9 @@ export default function createChainOfResponsibility<
   useBuildComponentCallback: () => UseBuildComponentCallback<Request, Props>;
 } {
   const defaultUseBuildComponentCallback: ProviderContext<Request, Props> = {
+    get enhancer() {
+      return undefined;
+    },
     get useBuildComponentCallback(): ProviderContext<Request, Props>['useBuildComponentCallback'] {
       throw new Error('useBuildComponentCallback() hook cannot be used outside of its corresponding <Provider>');
     }
@@ -124,36 +130,27 @@ export default function createChainOfResponsibility<
         : []
     );
 
+    const { enhancer: parentEnhancer } = useContext(context);
+
     const enhancer = useMemo(
       () =>
         // We are reversing because it is easier to read:
         // - With reverse, [a, b, c] will become a(b(c(fn)))
         // - Without reverse, [a, b, c] will become c(b(a(fn)))
-        applyMiddleware<[Request], ComponentType<Props> | false | null | undefined, [Init]>(
-          ...[...patchedMiddleware].reverse()
+        applyMiddleware<[Request], ResultComponent<Props>, [Init]>(
+          ...[...patchedMiddleware, ...(parentEnhancer ? [() => parentEnhancer] : [])].reverse()
         )(init as Init),
-      [init, middleware]
+      [init, middleware, parentEnhancer]
     );
 
-    const parentContextValue = useContext(context);
-    const parentUseBuildComponentCallback =
-      parentContextValue === defaultUseBuildComponentCallback
-        ? undefined
-        : parentContextValue.useBuildComponentCallback;
-
     const useBuildComponentCallback = useCallback<UseBuildComponentCallback<Request, Props>>(
-      (request, options = {}) =>
-        enhancer(request =>
-          parentUseBuildComponentCallback
-            ? parentUseBuildComponentCallback(request, options)
-            : options.fallbackComponent
-        )(request),
-      [enhancer, parentUseBuildComponentCallback]
+      (request, options = {}) => enhancer(() => options.fallbackComponent)(request),
+      [enhancer]
     );
 
     const contextValue = useMemo<ProviderContext<Request, Props>>(
-      () => ({ useBuildComponentCallback }),
-      [useBuildComponentCallback]
+      () => ({ enhancer, useBuildComponentCallback }),
+      [enhancer, useBuildComponentCallback]
     );
 
     return <context.Provider value={contextValue}>{children}</context.Provider>;


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Added

- Support nested provider of same type, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/compulim/react-chain-of-responsibility/pull/XXX)
   - Components will be built using middleware from `<Provider>` closer to the `<Proxy>` and fallback to those farther

## Specific changes

> Please list each individual specific change in this pull request.

- Updated `createChainOfResponsibility` and read parent context if any
   - If parent context is available, call parent enhancer before the `fallbackComponent`