### PR TITLE
Support `<Provider>`-less usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - Use `import { createChainOfResponsibility } from 'react-chain-of-responsibility'` instead
    - `import { createChainOfResponsibilityForFluentUI } from 'react-chain-of-responsibility/fluentUI'` for Fluent UI renderer function
 - Moved build tools from Babel to tsup/esbuild
+- Outside of `<Provider>`, when `useBuildComponentCallback` and `<Proxy>` is used with `fallbackComponent`, they will render the fallback component and no longer throwing exception
 
 ### Added
 
 - Support nested provider of same type, by [@compulim](https://github.com/compulim) in PR [#64](https://github.com/compulim/react-chain-of-responsibility/pull/64)
    - Components will be built using middleware from `<Provider>` closer to the `<Proxy>` and fallback to those farther away
+- Support `<Provider>`-less usage if `fallbackComponent` is provided, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/compulim/react-chain-of-responsibility/pull/XXX)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support nested provider of same type, by [@compulim](https://github.com/compulim) in PR [#64](https://github.com/compulim/react-chain-of-responsibility/pull/64)
    - Components will be built using middleware from `<Provider>` closer to the `<Proxy>` and fallback to those farther away
-- Support `<Provider>`-less usage if `fallbackComponent` is provided, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/compulim/react-chain-of-responsibility/pull/XXX)
+- Support `<Provider>`-less usage if `fallbackComponent` is specified, by [@compulim](https://github.com/compulim) in PR [#65](https://github.com/compulim/react-chain-of-responsibility/pull/65)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ type UseBuildComponentCallback<Request, Props> = (
 ) => ComponentType<Props> | false | null | undefined;
 ```
 
-The `fallbackComponent` is a component which all unhandled requests will sink into.
+The `fallbackComponent` is a component which all unhandled requests will sink into, including calls without ancestral `<Provider>`.
 
 ### API for Fluent UI
 

--- a/packages/react-chain-of-responsibility/src/createChainOfResponsibility.outsideProvider.callUseBuildComponentCallback.withFallbackComponent.test.tsx
+++ b/packages/react-chain-of-responsibility/src/createChainOfResponsibility.outsideProvider.callUseBuildComponentCallback.withFallbackComponent.test.tsx
@@ -29,7 +29,7 @@ test('when calling useBuildComponentCallback() outside of its <Provider> with fa
   const App = () => {
     const Component = useBuildComponentCallback()(undefined, { fallbackComponent: Fallback });
 
-    return !!Component && <Component />;
+    return Component ? <Component /> : null;
   };
 
   // WHEN: Render.

--- a/packages/react-chain-of-responsibility/src/createChainOfResponsibility.outsideProvider.callUseBuildComponentCallback.withFallbackComponent.test.tsx
+++ b/packages/react-chain-of-responsibility/src/createChainOfResponsibility.outsideProvider.callUseBuildComponentCallback.withFallbackComponent.test.tsx
@@ -29,7 +29,7 @@ test('when calling useBuildComponentCallback() outside of its <Provider> with fa
   const App = () => {
     const Component = useBuildComponentCallback()(undefined, { fallbackComponent: Fallback });
 
-    return Component && <Component />;
+    return !!Component && <Component />;
   };
 
   // WHEN: Render.

--- a/packages/react-chain-of-responsibility/src/createChainOfResponsibility.outsideProvider.callUseBuildComponentCallback.withFallbackComponent.test.tsx
+++ b/packages/react-chain-of-responsibility/src/createChainOfResponsibility.outsideProvider.callUseBuildComponentCallback.withFallbackComponent.test.tsx
@@ -2,7 +2,7 @@
 /// <reference types="@types/jest" />
 
 import { render } from '@testing-library/react';
-import React, { Fragment } from 'react';
+import React from 'react';
 
 import createChainOfResponsibility from './createChainOfResponsibility';
 
@@ -20,19 +20,21 @@ afterEach(() => {
   consoleErrorMock.mockRestore();
 });
 
-test('when calling useBuildComponentCallback() outside of its <Provider> should throw', () => {
+test('when calling useBuildComponentCallback() outside of its <Provider> with fallbackComponent should render', () => {
   // GIVEN: useBuildComponentCallback() from a newly created chain of responsibility.
   const { useBuildComponentCallback } = createChainOfResponsibility<undefined, Props>();
 
-  const App = () => {
-    useBuildComponentCallback();
+  const Fallback = () => <div>Hello, World!</div>;
 
-    return <Fragment />;
+  const App = () => {
+    const Component = useBuildComponentCallback()(undefined, { fallbackComponent: Fallback });
+
+    return Component && <Component />;
   };
 
   // WHEN: Render.
-  // THEN: It should throw an error saying useBuildComponentCallback() hook cannot be used outside of its corresponding <Provider>.
-  expect(() => render(<App />)).toThrow(
-    'useBuildComponentCallback() hook cannot be used outside of its corresponding <Provider>'
-  );
+  const result = render(<App />);
+
+  // THEN: Should render fallbackComponent.
+  expect(result.container).toHaveProperty('textContent', 'Hello, World!');
 });

--- a/packages/react-chain-of-responsibility/src/createChainOfResponsibility.outsideProvider.callUseBuildComponentCallback.withoutFallbackComponent.test.tsx
+++ b/packages/react-chain-of-responsibility/src/createChainOfResponsibility.outsideProvider.callUseBuildComponentCallback.withoutFallbackComponent.test.tsx
@@ -1,0 +1,36 @@
+/** @jest-environment jsdom */
+/// <reference types="@types/jest" />
+
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import createChainOfResponsibility from './createChainOfResponsibility';
+
+type Props = { children?: never };
+
+let consoleErrorMock: jest.SpyInstance;
+
+beforeEach(() => {
+  // Currently, there is no way to hide the caught exception thrown by render().
+  // We are mocking `console.log` to hide the exception.
+  consoleErrorMock = jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
+});
+
+afterEach(() => {
+  consoleErrorMock.mockRestore();
+});
+
+test('when calling useBuildComponentCallback() outside of its <Provider> should throw', () => {
+  // GIVEN: useBuildComponentCallback() from a newly created chain of responsibility.
+  const { useBuildComponentCallback } = createChainOfResponsibility<undefined, Props>();
+
+  const App = () => {
+    const Component = useBuildComponentCallback()(undefined);
+
+    return Component && <Component />;
+  };
+
+  // WHEN: Render.
+  // THEN: It should throw an error saying "This component/hook cannot be used outside of its corresponding <Provider>".
+  expect(() => render(<App />)).toThrow('This component/hook cannot be used outside of its corresponding <Provider>');
+});

--- a/packages/react-chain-of-responsibility/src/createChainOfResponsibility.outsideProvider.callUseBuildComponentCallback.withoutFallbackComponent.test.tsx
+++ b/packages/react-chain-of-responsibility/src/createChainOfResponsibility.outsideProvider.callUseBuildComponentCallback.withoutFallbackComponent.test.tsx
@@ -27,7 +27,7 @@ test('when calling useBuildComponentCallback() outside of its <Provider> should 
   const App = () => {
     const Component = useBuildComponentCallback()(undefined);
 
-    return Component && <Component />;
+    return !!Component && <Component />;
   };
 
   // WHEN: Render.

--- a/packages/react-chain-of-responsibility/src/createChainOfResponsibility.outsideProvider.callUseBuildComponentCallback.withoutFallbackComponent.test.tsx
+++ b/packages/react-chain-of-responsibility/src/createChainOfResponsibility.outsideProvider.callUseBuildComponentCallback.withoutFallbackComponent.test.tsx
@@ -27,7 +27,7 @@ test('when calling useBuildComponentCallback() outside of its <Provider> should 
   const App = () => {
     const Component = useBuildComponentCallback()(undefined);
 
-    return !!Component && <Component />;
+    return Component ? <Component /> : null;
   };
 
   // WHEN: Render.

--- a/packages/react-chain-of-responsibility/src/createChainOfResponsibility.outsideProvider.renderProxy.withFallbackComponent.test.tsx
+++ b/packages/react-chain-of-responsibility/src/createChainOfResponsibility.outsideProvider.renderProxy.withFallbackComponent.test.tsx
@@ -1,0 +1,34 @@
+/** @jest-environment jsdom */
+/// <reference types="@types/jest" />
+
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import createChainOfResponsibility from './createChainOfResponsibility';
+
+type Props = { children?: never };
+
+let consoleErrorMock: jest.SpyInstance;
+
+beforeEach(() => {
+  // Currently, there is no way to hide the caught exception thrown by render().
+  // We are mocking `console.log` to hide the exception.
+  consoleErrorMock = jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
+});
+
+afterEach(() => {
+  consoleErrorMock.mockRestore();
+});
+
+test('when rendering <Proxy> outside of its <Provider> with fallbackComponent should render', () => {
+  // GIVEN: A <Proxy> of a newly created chain of responsibility.
+  const { Proxy } = createChainOfResponsibility<undefined, Props>();
+
+  const Fallback = () => <div>Hello, World!</div>;
+
+  // WHEN: Render.
+  const result = render(<Proxy fallbackComponent={Fallback} />);
+
+  // THEN: It should throw an error saying <Proxy> cannot be used outside of its corresponding <Provider>.
+  expect(result.container).toHaveProperty('textContent', 'Hello, World!');
+});

--- a/packages/react-chain-of-responsibility/src/createChainOfResponsibility.outsideProvider.renderProxy.withoutFallbackComponent.test.tsx
+++ b/packages/react-chain-of-responsibility/src/createChainOfResponsibility.outsideProvider.renderProxy.withoutFallbackComponent.test.tsx
@@ -20,11 +20,11 @@ afterEach(() => {
   consoleErrorMock.mockRestore();
 });
 
-test('when rendering <Proxy> outside of its <Provider> should throw', () => {
+test('when rendering <Proxy> outside of its <Provider> without fallbackComponent should throw', () => {
   // GIVEN: A <Proxy> of a newly created chain of responsibility.
   const { Proxy } = createChainOfResponsibility<undefined, Props>();
 
   // WHEN: Render.
-  // THEN: It should throw an error saying <Proxy> cannot be used outside of its corresponding <Provider>.
-  expect(() => render(<Proxy />)).toThrow('<Proxy> cannot be used outside of its corresponding <Provider>');
+  // THEN: It should throw an error saying "This component/hook cannot be used outside of its corresponding <Provider>".
+  expect(() => render(<Proxy />)).toThrow('This component/hook cannot be used outside of its corresponding <Provider>');
 });


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Breaking changes

- Outside of `<Provider>`, when `useBuildComponentCallback` and `<Proxy>` is used with `fallbackComponent`, they will render the fallback component and no longer throwing exception

### Added

- Support `<Provider>`-less usage if `fallbackComponent` is specified, by [@compulim](https://github.com/compulim) in PR [#65](https://github.com/compulim/react-chain-of-responsibility/pull/65)

## Specific changes

> Please list each individual specific change in this pull request.

- Updated `createChainOfResponsibility.tsx` to support `<Provider>`-less usage if `fallbackComponent` is specified
- Updated `README.md` about `<Provider>`-less usage