### PR TITLE
Support `init` or `request` of type `void`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support nested provider of same type, by [@compulim](https://github.com/compulim) in PR [#64](https://github.com/compulim/react-chain-of-responsibility/pull/64)
    - Components will be built using middleware from `<Provider>` closer to the `<Proxy>` and fallback to those farther away
 - Support `<Provider>`-less usage if `fallbackComponent` is specified, by [@compulim](https://github.com/compulim) in PR [#65](https://github.com/compulim/react-chain-of-responsibility/pull/65)
-- Support omitting `init` or `request` props in `<Provider>` and `<Proxy>` if they are of type `void`, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/compulim/react-chain-of-responsibility/pull/XXX)
+- Support omitting `init` or `request` props in `<Provider>` and `<Proxy>` if they are of type `void`, by [@compulim](https://github.com/compulim) in PR [#66](https://github.com/compulim/react-chain-of-responsibility/pull/66)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support nested provider of same type, by [@compulim](https://github.com/compulim) in PR [#64](https://github.com/compulim/react-chain-of-responsibility/pull/64)
    - Components will be built using middleware from `<Provider>` closer to the `<Proxy>` and fallback to those farther away
 - Support `<Provider>`-less usage if `fallbackComponent` is specified, by [@compulim](https://github.com/compulim) in PR [#65](https://github.com/compulim/react-chain-of-responsibility/pull/65)
+- Support omitting `init` or `request` props in `<Provider>` and `<Proxy>` if they are of type `void`, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/compulim/react-chain-of-responsibility/pull/XXX)
 
 ### Changed
 

--- a/packages/react-chain-of-responsibility/src/createChainOfResponsibility.tsx
+++ b/packages/react-chain-of-responsibility/src/createChainOfResponsibility.tsx
@@ -31,12 +31,14 @@ type ProviderContext<Request, Props> = {
 type ProviderProps<Request, Props, Init> = PropsWithChildren<{
   middleware: readonly ComponentMiddleware<Request, Props, Init>[];
 }> &
-  (Init extends never | undefined ? { init?: Init } : { init: Init });
+  (Init extends never | void ? { init?: undefined } : Init extends undefined ? { init?: Init } : { init: Init });
 
 type ProxyProps<Request, Props> = PropsWithChildren<
-  Request extends never | undefined
-    ? Props & { fallbackComponent?: ComponentType<Props>; request?: Request }
-    : Props & { fallbackComponent?: ComponentType<Props>; request: Request }
+  Request extends never | void
+    ? Props & { fallbackComponent?: ComponentType<Props>; request?: undefined }
+    : Request extends undefined
+      ? Props & { fallbackComponent?: ComponentType<Props>; request?: Request }
+      : Props & { fallbackComponent?: ComponentType<Props>; request: Request }
 >;
 
 type Options = {

--- a/packages/react-chain-of-responsibility/src/createChainOfResponsibility.types.test.tsx
+++ b/packages/react-chain-of-responsibility/src/createChainOfResponsibility.types.test.tsx
@@ -29,3 +29,27 @@ test('constructing middleware using all typings from "types" should render', () 
   // THEN: It should render "hello world".
   expect(result.container).toHaveProperty('textContent', 'Hello, World!');
 });
+
+test('constructing middleware with minimal typings should render', () => {
+  // GIVEN: A chain of responsibility which specify init, props, and request.
+  const { Provider, Proxy, types } = createChainOfResponsibility<void, Record<string, never>, void>();
+
+  const middleware: (typeof types.middleware)[] = [
+    (_init: typeof types.init) => _next => (_request: typeof types.request) => (_props: typeof types.props) => (
+      <span>Hello, World</span>
+    )
+  ];
+
+  const App = () => (
+    // Allows <Provider> without "init" prop and <Proxy> without "request" prop.
+    <Provider middleware={middleware}>
+      <Proxy />
+    </Provider>
+  );
+
+  // WHEN: Render.
+  const result = render(<App />);
+
+  // THEN: It should render "hello world".
+  expect(result.container).toHaveProperty('textContent', 'Hello, World!');
+});

--- a/packages/react-chain-of-responsibility/src/createChainOfResponsibility.types.test.tsx
+++ b/packages/react-chain-of-responsibility/src/createChainOfResponsibility.types.test.tsx
@@ -36,7 +36,7 @@ test('constructing middleware with minimal typings should render', () => {
 
   const middleware: (typeof types.middleware)[] = [
     (_init: typeof types.init) => _next => (_request: typeof types.request) => (_props: typeof types.props) => (
-      <span>Hello, World</span>
+      <span>Hello, World!</span>
     )
   ];
 


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Added

- Support omitting `init` or `request` props in `<Provider>` and `<Proxy>` if they are of type `void`, by [@compulim](https://github.com/compulim) in PR [#66](https://github.com/compulim/react-chain-of-responsibility/pull/66)

## Specific changes

> Please list each individual specific change in this pull request.

- Updated `createChainOfResponsibility` to pre-set `init` and `request` to `undefined` when they are of type `void`, so they can be omitted in the props of `<Provider>` and `<Proxy>`
- Added a test for `init` and `request` of type `void`