### PR TITLE
Simplify `useBuildComponentCallback`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Simplified `useBuildComponentCallback` hook by returning a component or `undefined`, and will no longer return `false` and `null`, by [@compulim](https://github.com/compulim) in PR [#81](https://github.com/compulim/react-chain-of-responsibility/pull/81)
+- Simplified `useBuildComponentCallback` hook by returning a component or `undefined`, and will no longer return `false` and `null`, by [@compulim](https://github.com/compulim) in PR [#82](https://github.com/compulim/react-chain-of-responsibility/pull/82)
 - Bumped dependencies, in PR [#80](https://github.com/compulim/react-chain-of-responsibility/pull/80)
   - Development dependencies
     - [`@babel/preset-env@7.27.2`](https://npmjs.com/package/@babel/preset-env/v/7.27.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Simplified `useBuildComponentCallback` hook by returning a component or `undefined`, and will no longer return `false` and `null`, by [@compulim](https://github.com/compulim) in PR [#81](https://github.com/compulim/react-chain-of-responsibility/pull/81)
 - Bumped dependencies, in PR [#80](https://github.com/compulim/react-chain-of-responsibility/pull/80)
   - Development dependencies
     - [`@babel/preset-env@7.27.2`](https://npmjs.com/package/@babel/preset-env/v/7.27.2)

--- a/README.md
+++ b/README.md
@@ -392,13 +392,15 @@ type MiddlewareComponentProps<Request, Props, Init> = Props &
 ### API of `useBuildComponentCallback`
 
 ```ts
-type UseBuildComponentCallbackOptions<Props> = { fallbackComponent?: ComponentType<Props> | false | null | undefined };
+type UseBuildComponentCallbackOptions<Props> = { fallbackComponent?: ComponentType<Props> | undefined };
 
 type UseBuildComponentCallback<Request, Props> = (
   request: Request,
   options?: UseBuildComponentCallbackOptions<Props>
-) => ComponentType<Props> | false | null | undefined;
+) => ComponentType<Props> | undefined;
 ```
+
+For simplicity, instead of returning a component or `false`/`null`/`undefined`, the `useBuildComponentCallback` will only return a component or `undefined`.
 
 The `fallbackComponent` is a component which all unhandled requests will sink into, including calls without ancestral `<Provider>`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-chain-of-responsibility-root",
-  "version": "0.2.1-0",
+  "version": "0.3.0-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-chain-of-responsibility-root",
-      "version": "0.2.1-0",
+      "version": "0.3.0-0",
       "license": "MIT",
       "workspaces": [
         "packages/react-chain-of-responsibility",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9840,6 +9840,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10422,6 +10423,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -10432,7 +10434,8 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "node_modules/property-information": {
       "version": "7.1.0",
@@ -12701,9 +12704,6 @@
     "packages/react-chain-of-responsibility": {
       "version": "0.0.0-0",
       "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.8.1"
-      },
       "devDependencies": {
         "@babel/preset-env": "^7.27.2",
         "@babel/preset-react": "^7.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chain-of-responsibility-root",
-  "version": "0.2.1-0",
+  "version": "0.3.0-0",
   "description": "",
   "private": true,
   "author": "William Wong (https://github.com/compulim)",

--- a/packages/react-chain-of-responsibility/package.json
+++ b/packages/react-chain-of-responsibility/package.json
@@ -129,8 +129,5 @@
   },
   "peerDependencies": {
     "react": ">=16.8.0"
-  },
-  "dependencies": {
-    "prop-types": "^15.8.1"
   }
 }

--- a/packages/react-chain-of-responsibility/src/createChainOfResponsibility.tsx
+++ b/packages/react-chain-of-responsibility/src/createChainOfResponsibility.tsx
@@ -134,7 +134,7 @@ export default function createChainOfResponsibility<
                 if (isValidElement(returnValue)) {
                   throw new Error('middleware must not return React element directly');
                 } else if (
-                  (returnValue as unknown) !== false &&
+                  returnValue !== false &&
                   returnValue !== null &&
                   typeof returnValue !== 'undefined' &&
                   !isReactComponent(returnValue)

--- a/packages/react-chain-of-responsibility/src/createChainOfResponsibility.types.test.tsx
+++ b/packages/react-chain-of-responsibility/src/createChainOfResponsibility.types.test.tsx
@@ -32,7 +32,7 @@ test('constructing middleware using all typings from "types" should render', () 
 
 test('constructing middleware with minimal typings should render', () => {
   // GIVEN: A chain of responsibility which specify init, props, and request.
-  const { Provider, Proxy, types: _types } = createChainOfResponsibility<void, Record<string, never>, void>();
+  const { Provider, Proxy, types: _types } = createChainOfResponsibility<undefined, Record<string, never>, void>();
 
   const middleware: (typeof _types.middleware)[] = [
     (_init: typeof _types.init) => _next => (_request: typeof _types.request) => (_props: typeof _types.props) => (


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Changed

- Simplified `useBuildComponentCallback` hook by returning a component or `undefined`, and will no longer return `false` and `null`, by [@compulim](https://github.com/compulim) in PR [#82](https://github.com/compulim/react-chain-of-responsibility/pull/82)

## Specific changes

> Please list each individual specific change in this pull request.

- Simplified `useBuildComponentCallback` hook by returning a component or `undefined`, and will no longer return `false` and `null`
   - `false` and `null` is still accepted from middleware, but we will return `undefined` instead
- Removed `prop-types` as it is no longer used