### PR TITLE
Side effect `bindProps` should be executed by not excessively memoizing things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- (Preview) 💢 Changed signature to return wrapped return value, instead of plain `ComponentType`, by [@compulim](https://github.com/compulim) in PR [#91](https://github.com/compulim/react-chain-of-responsibility/pull/91), [#92](https://github.com/compulim/react-chain-of-responsibility/pull/92), and [#99](https://github.com/compulim/react-chain-of-responsibility/pull/99)
+- (Preview) 💢 Changed signature to return wrapped return value, instead of plain `ComponentType`, by [@compulim](https://github.com/compulim) in PR [#91](https://github.com/compulim/react-chain-of-responsibility/pull/91), [#92](https://github.com/compulim/react-chain-of-responsibility/pull/92), [#99](https://github.com/compulim/react-chain-of-responsibility/pull/99), and [#100](https://github.com/compulim/react-chain-of-responsibility/pull/100)
 - Use `handler-chain` package, by [@compulim](https://github.com/compulim) in PR [#93](https://github.com/compulim/react-chain-of-responsibility/pull/93)
 - Bumped dependencies, in PR [#97](https://github.com/compulim/react-chain-of-responsibility/pull/97)
   - Development dependencies

--- a/packages/react-chain-of-responsibility/src/preview/createChainOfResponsibilityAsRenderCallback.tsx
+++ b/packages/react-chain-of-responsibility/src/preview/createChainOfResponsibilityAsRenderCallback.tsx
@@ -235,12 +235,8 @@ function createChainOfResponsibility<
               return;
             }
 
-            // Convert fallback component as renderer.
-            return createComponentHandlerResult(() => (
-              // Currently, there are no ways to set `bindProps` to `fallbackComponent`.
-              // `fallbackComponent` do not need `overridingProps` because it is the last one in the chain, it would not have the next() function.
-              <ComponentWithProps component={fallbackComponent} />
-            ));
+            // `fallbackComponent` do not need `overridingProps` because it is the last one in the chain, it would not have the next() function.
+            return reactComponent(fallbackComponent);
           })(request);
 
         return (

--- a/packages/react-chain-of-responsibility/src/preview/createChainOfResponsibilityAsRenderCallback.tsx
+++ b/packages/react-chain-of-responsibility/src/preview/createChainOfResponsibilityAsRenderCallback.tsx
@@ -328,15 +328,11 @@ function createChainOfResponsibility<
     return <BuildContext.Provider value={contextValue}>{children}</BuildContext.Provider>;
   }
 
-  const ChainOfResponsibilityProxy = function ChainOfResponsibilityProxy({
-    fallbackComponent,
-    request,
-    ...props
-  }: ProxyProps<Request, Props>): ReactNode {
+  function ChainOfResponsibilityProxy({ fallbackComponent, request, ...props }: ProxyProps<Request, Props>) {
     const result = useBuildRenderCallback()(request, { fallbackComponent })?.(props as Props);
 
     return result ? <Fragment>{result}</Fragment> : null;
-  };
+  }
 
   const MemoizedChainOfResponsibilityProvider =
     memo<ProviderProps<Request, Props, Init>>(ChainOfResponsibilityProvider);

--- a/packages/react-chain-of-responsibility/src/preview/tests/sideEffect.test.tsx
+++ b/packages/react-chain-of-responsibility/src/preview/tests/sideEffect.test.tsx
@@ -1,0 +1,99 @@
+/** @jest-environment jsdom */
+/// <reference types="@types/jest" />
+
+import { scenario } from '@testduet/given-when-then';
+import { render } from '@testing-library/react';
+import React, { Fragment } from 'react';
+
+import createChainOfResponsibility, { type InferMiddleware } from '../createChainOfResponsibilityAsRenderCallback';
+
+type Props = { readonly children?: never };
+type Request = void;
+
+scenario('side effect in bindProps', bdd => {
+  bdd
+    .given('a TestComponent using chain of responsiblity', () => {
+      const { Provider, Proxy, reactComponent, useBuildRenderCallback } = createChainOfResponsibility<Request, Props>();
+
+      let count = 0;
+      const renderCall = jest.fn();
+
+      const MyComponent = function MyComponent({ value }: Props & { readonly value: number }) {
+        renderCall();
+
+        return <Fragment>Hello, World! ({value})</Fragment>;
+      };
+
+      const middleware: readonly InferMiddleware<typeof Provider>[] = [
+        // `bindProps` has side effect.
+        () => () => () => reactComponent(MyComponent, { value: ++count })
+      ];
+
+      return {
+        middleware,
+        MyComponent,
+        Provider,
+        Proxy,
+        renderCall,
+        useBuildRenderCallback
+      };
+    })
+    .and.oneOf([
+      [
+        'rendered using useBuildRenderCallback()',
+        ({ middleware, Provider, renderCall, useBuildRenderCallback }) => {
+          function MyProxy() {
+            const result = useBuildRenderCallback()()?.({});
+
+            return result ? <Fragment>{result}</Fragment> : null;
+          }
+
+          return {
+            renderCall,
+            TestComponent: function TestComponent() {
+              return (
+                <Provider middleware={middleware}>
+                  <MyProxy />
+                </Provider>
+              );
+            }
+          };
+        }
+      ],
+      [
+        'rendered using <Proxy>',
+        ({ middleware, Provider, Proxy, renderCall }) => {
+          return {
+            renderCall,
+            TestComponent: function TestComponent() {
+              return (
+                <Provider middleware={middleware}>
+                  <Proxy request={undefined} />
+                </Provider>
+              );
+            }
+          };
+        }
+      ]
+    ])
+
+    // ---
+
+    .when('the component is rendered', ({ TestComponent }) => render(<TestComponent />))
+    .then('textContent should match', (_, { container }) =>
+      expect(container).toHaveProperty('textContent', 'Hello, World! (1)')
+    )
+    .and('should have rendered once', ({ renderCall }) => expect(renderCall).toHaveBeenCalledTimes(1))
+
+    // ---
+
+    .when('the component is rendered again', ({ TestComponent }, result) => {
+      result.rerender(<TestComponent />);
+
+      return result;
+    })
+    .then('textContent should match', (_, { container }) =>
+      expect(container).toHaveProperty('textContent', 'Hello, World! (2)')
+    )
+    .and('should have rendered twice', ({ renderCall }) => expect(renderCall).toHaveBeenCalledTimes(2));
+});

--- a/packages/react-chain-of-responsibility/src/preview/tests/stability.changeFallbackComponent.tsx
+++ b/packages/react-chain-of-responsibility/src/preview/tests/stability.changeFallbackComponent.tsx
@@ -1,0 +1,93 @@
+/** @jest-environment jsdom */
+/// <reference types="@types/jest" />
+
+import { scenario } from '@testduet/given-when-then';
+import { render } from '@testing-library/react';
+import React, { Fragment, memo, type ComponentType } from 'react';
+
+import createChainOfResponsibility, { type InferMiddleware } from '../createChainOfResponsibilityAsRenderCallback';
+
+type Props = { readonly children?: never };
+type Request = number;
+
+scenario('stability test with changing fallbackComponent', bdd => {
+  bdd
+    .given('a TestComponent using chain of responsiblity', () => {
+      const { Provider, useBuildRenderCallback } = createChainOfResponsibility<Request, Props>();
+
+      const alohaCall = jest.fn();
+
+      const Aloha = function MyComponent() {
+        alohaCall();
+
+        return <Fragment>Aloha!</Fragment>;
+      };
+
+      const helloWorldCall = jest.fn();
+
+      const HelloWorld = function MyComponent() {
+        helloWorldCall();
+
+        return <Fragment>Hello, World!</Fragment>;
+      };
+
+      const middleware: readonly InferMiddleware<typeof Provider>[] = [];
+
+      function MyProxy({ fallbackComponent }: { readonly fallbackComponent: ComponentType<Props> }) {
+        // We are using `useBuildRenderCallback` for less memoization.
+        const result = useBuildRenderCallback()(1, { fallbackComponent })?.({});
+
+        return result ? <Fragment>{result}</Fragment> : null;
+      }
+
+      return {
+        Aloha,
+        alohaCall,
+        HelloWorld,
+        helloWorldCall,
+        TestComponent: function TestComponent({
+          fallbackComponent
+        }: {
+          readonly fallbackComponent: ComponentType<Props>;
+        }) {
+          return (
+            <Provider middleware={middleware}>
+              <MyProxy fallbackComponent={fallbackComponent} />
+            </Provider>
+          );
+        }
+      };
+    })
+
+    // ---
+
+    .when('the component is rendered with fallback component of <HelloWorld>', ({ HelloWorld, TestComponent }) =>
+      render(<TestComponent fallbackComponent={HelloWorld} />)
+    )
+    .then('textContent should match', (_, { container }) =>
+      expect(container).toHaveProperty('textContent', 'Hello, World!')
+    )
+    .and('<HelloWorld> should have been rendered once', ({ helloWorldCall }) =>
+      expect(helloWorldCall).toHaveBeenCalledTimes(1)
+    )
+
+    // ---
+
+    .when('the component is rendered again with same fallback component', ({ HelloWorld, TestComponent }) =>
+      render(<TestComponent fallbackComponent={HelloWorld} />)
+    )
+    .then('textContent should match', (_, { container }) =>
+      expect(container).toHaveProperty('textContent', 'Hello, World!')
+    )
+    .and('<HelloWorld> should not have been rendered again', ({ helloWorldCall }) =>
+      expect(helloWorldCall).toHaveBeenCalledTimes(1)
+    )
+
+    // ---
+
+    .when('the component is rendered with fallback component of <Aloha>', ({ Aloha, TestComponent }) =>
+      render(<TestComponent fallbackComponent={Aloha} />)
+    )
+    .then('textContent should match', (_, { container }) => expect(container).toHaveProperty('textContent', 'Aloha!'))
+    .and('<Aloha> should have been rendered once', ({ alohaCall }) => expect(alohaCall).toHaveBeenCalledTimes(1));
+});

--- a/packages/react-chain-of-responsibility/src/preview/tests/stability.changeFallbackComponent.tsx
+++ b/packages/react-chain-of-responsibility/src/preview/tests/stability.changeFallbackComponent.tsx
@@ -3,9 +3,9 @@
 
 import { scenario } from '@testduet/given-when-then';
 import { render } from '@testing-library/react';
-import React, { Fragment, memo, type ComponentType } from 'react';
+import React, { Fragment, type ComponentType } from 'react';
 
-import createChainOfResponsibility, { type InferMiddleware } from '../createChainOfResponsibilityAsRenderCallback';
+import createChainOfResponsibility, { type InferMiddleware } from '../createChainOfResponsibilityAsRenderCallback.tsx';
 
 type Props = { readonly children?: never };
 type Request = number;

--- a/packages/react-chain-of-responsibility/src/preview/tests/stability.changeMiddleware.test.tsx
+++ b/packages/react-chain-of-responsibility/src/preview/tests/stability.changeMiddleware.test.tsx
@@ -3,7 +3,7 @@
 
 import { scenario } from '@testduet/given-when-then';
 import { render } from '@testing-library/react';
-import React, { Fragment, memo } from 'react';
+import React, { Fragment } from 'react';
 
 import createChainOfResponsibility, { type InferMiddleware } from '../createChainOfResponsibilityAsRenderCallback';
 
@@ -17,34 +17,39 @@ scenario('stability test with changing middleware', bdd => {
 
       const alohaCall = jest.fn();
 
-      // Middleware prop change always re-render.
-      // Memoizing <Aloha> to focus on whether the component is rendering as waste.
-      const Aloha = memo(function Aloha() {
+      const Aloha = function Aloha() {
         alohaCall();
 
         return <Fragment>Aloha!</Fragment>;
-      });
+      };
+
+      // Changing middleware always call `reactComponent(...)` again and would result in wasted rendering.
+      // Until we do equality check on the return value of `reactComponent(...)` to see if they are different instances but same result.
+      // Otherwise, we need to cache the `reactComponent(Aloha)` for testing purpose.
+      // This way of testing it is preferred over `memo(Aloha)`.
+      // In production, web devs should do `memo(Aloha)` instead.
+      const renderAloha = reactComponent(Aloha);
 
       const helloWorldCall = jest.fn();
 
-      // Middleware prop change always re-render.
-      // Memoizing <HelloWorld> to focus on whether the component is rendering as waste.
-      const HelloWorld = memo(function HelloWorld() {
+      const HelloWorld = function HelloWorld() {
         helloWorldCall();
 
         return <Fragment>Hello, World!</Fragment>;
-      });
+      };
+
+      const renderHelloWorld = reactComponent(HelloWorld);
 
       const myProxyCall = jest.fn();
 
-      const MyProxy = memo(function MyProxy({ request }: { readonly request: number }) {
+      const MyProxy = function MyProxy({ request }: { readonly request: number }) {
         myProxyCall();
 
         // We are using `useBuildRenderCallback` for less memoization.
         const result = useBuildRenderCallback()(request)?.({});
 
         return result ? <Fragment>{result}</Fragment> : null;
-      });
+      };
 
       return Object.freeze({
         Aloha,
@@ -52,7 +57,8 @@ scenario('stability test with changing middleware', bdd => {
         HelloWorld,
         helloWorldCall,
         myProxyCall,
-        reactComponent,
+        renderAloha,
+        renderHelloWorld,
         TestComponent: function TestComponent({
           middleware
         }: {
@@ -66,8 +72,11 @@ scenario('stability test with changing middleware', bdd => {
         }
       });
     })
-    .when('the component is rendered', ({ HelloWorld, reactComponent, TestComponent }) =>
-      render(<TestComponent middleware={[() => () => () => reactComponent(HelloWorld)]} />)
+
+    // ---
+
+    .when('the component is rendered', ({ renderHelloWorld, TestComponent }) =>
+      render(<TestComponent middleware={[() => () => () => renderHelloWorld]} />)
     )
     .then('textContent should match', (_, { container }) =>
       expect(container).toHaveProperty('textContent', 'Hello, World!')
@@ -76,11 +85,14 @@ scenario('stability test with changing middleware', bdd => {
       expect(helloWorldCall).toHaveBeenCalledTimes(1)
     )
     .and('<MyProxy> should have been rendered once', ({ myProxyCall }) => expect(myProxyCall).toHaveBeenCalledTimes(1))
+
+    // ---
+
     .when(
       'the component is re-rendered with a different instance but same middleware',
-      ({ HelloWorld, reactComponent, TestComponent }, result) => {
+      ({ renderHelloWorld, TestComponent }, result) => {
         // Still rendering <HelloWorld>, but in a different middleware.
-        result.rerender(<TestComponent middleware={[() => () => () => reactComponent(HelloWorld)]} />);
+        result.rerender(<TestComponent middleware={[() => () => () => renderHelloWorld]} />);
 
         return result;
       }
@@ -94,10 +106,13 @@ scenario('stability test with changing middleware', bdd => {
     // Every time middleware change, it should invalidate `useBuildRenderCallback`.
     // In future, we may do more granular check to see if enhancer actually changed or not and reduce wasted rendering.
     .and('<MyProxy> should have been rendered once', ({ myProxyCall }) => expect(myProxyCall).toHaveBeenCalledTimes(2))
+
+    // ---
+
     .when(
       'the component is re-rendered with a different instance but same middleware',
-      ({ Aloha, reactComponent, TestComponent }, result) => {
-        result.rerender(<TestComponent middleware={[() => () => () => reactComponent(Aloha)]} />);
+      ({ renderAloha, TestComponent }, result) => {
+        result.rerender(<TestComponent middleware={[() => () => () => renderAloha]} />);
 
         return result;
       }

--- a/packages/react-chain-of-responsibility/src/preview/tests/stability.changeMiddleware.test.tsx
+++ b/packages/react-chain-of-responsibility/src/preview/tests/stability.changeMiddleware.test.tsx
@@ -1,0 +1,113 @@
+/** @jest-environment jsdom */
+/// <reference types="@types/jest" />
+
+import { scenario } from '@testduet/given-when-then';
+import { render } from '@testing-library/react';
+import React, { Fragment, memo } from 'react';
+
+import createChainOfResponsibility, { type InferMiddleware } from '../createChainOfResponsibilityAsRenderCallback';
+
+type Props = { readonly children?: never };
+type Request = number;
+
+scenario('stability test with changing middleware', bdd => {
+  bdd
+    .given('a TestComponent using chain of responsiblity', () => {
+      const { Provider, reactComponent, useBuildRenderCallback } = createChainOfResponsibility<Request, Props>();
+
+      const alohaCall = jest.fn();
+
+      // Middleware prop change always re-render.
+      // Memoizing <Aloha> to focus on whether the component is rendering as waste.
+      const Aloha = memo(function Aloha() {
+        alohaCall();
+
+        return <Fragment>Aloha!</Fragment>;
+      });
+
+      const helloWorldCall = jest.fn();
+
+      // Middleware prop change always re-render.
+      // Memoizing <HelloWorld> to focus on whether the component is rendering as waste.
+      const HelloWorld = memo(function HelloWorld() {
+        helloWorldCall();
+
+        return <Fragment>Hello, World!</Fragment>;
+      });
+
+      const myProxyCall = jest.fn();
+
+      const MyProxy = memo(function MyProxy({ request }: { readonly request: number }) {
+        myProxyCall();
+
+        // We are using `useBuildRenderCallback` for less memoization.
+        const result = useBuildRenderCallback()(request)?.({});
+
+        return result ? <Fragment>{result}</Fragment> : null;
+      });
+
+      return Object.freeze({
+        Aloha,
+        alohaCall,
+        HelloWorld,
+        helloWorldCall,
+        myProxyCall,
+        reactComponent,
+        TestComponent: function TestComponent({
+          middleware
+        }: {
+          readonly middleware: readonly InferMiddleware<typeof Provider>[];
+        }) {
+          return (
+            <Provider middleware={middleware}>
+              <MyProxy request={1} />
+            </Provider>
+          );
+        }
+      });
+    })
+    .when('the component is rendered', ({ HelloWorld, reactComponent, TestComponent }) =>
+      render(<TestComponent middleware={[() => () => () => reactComponent(HelloWorld)]} />)
+    )
+    .then('textContent should match', (_, { container }) =>
+      expect(container).toHaveProperty('textContent', 'Hello, World!')
+    )
+    .and('<HelloWorld> should have been rendered once', ({ helloWorldCall }) =>
+      expect(helloWorldCall).toHaveBeenCalledTimes(1)
+    )
+    .and('<MyProxy> should have been rendered once', ({ myProxyCall }) => expect(myProxyCall).toHaveBeenCalledTimes(1))
+    .when(
+      'the component is re-rendered with a different instance but same middleware',
+      ({ HelloWorld, reactComponent, TestComponent }, result) => {
+        // Still rendering <HelloWorld>, but in a different middleware.
+        result.rerender(<TestComponent middleware={[() => () => () => reactComponent(HelloWorld)]} />);
+
+        return result;
+      }
+    )
+    .then('textContent should match', (_, { container }) =>
+      expect(container).toHaveProperty('textContent', 'Hello, World!')
+    )
+    .and('<HelloWorld> should not have been re-rendered', ({ helloWorldCall }) =>
+      expect(helloWorldCall).toHaveBeenCalledTimes(1)
+    )
+    // Every time middleware change, it should invalidate `useBuildRenderCallback`.
+    // In future, we may do more granular check to see if enhancer actually changed or not and reduce wasted rendering.
+    .and('<MyProxy> should have been rendered once', ({ myProxyCall }) => expect(myProxyCall).toHaveBeenCalledTimes(2))
+    .when(
+      'the component is re-rendered with a different instance but same middleware',
+      ({ Aloha, reactComponent, TestComponent }, result) => {
+        result.rerender(<TestComponent middleware={[() => () => () => reactComponent(Aloha)]} />);
+
+        return result;
+      }
+    )
+    .then('textContent should match', (_, { container }) => expect(container).toHaveProperty('textContent', 'Aloha!'))
+    .and('<Aloha> should have been rendered once', ({ alohaCall }) => expect(alohaCall).toHaveBeenCalledTimes(1))
+    .and('<HelloWorld> should have been rendered once', ({ helloWorldCall }) =>
+      expect(helloWorldCall).toHaveBeenCalledTimes(1)
+    )
+    .and('<MyProxy> should have been rendered 3 times', ({ myProxyCall }) =>
+      expect(myProxyCall).toHaveBeenCalledTimes(3)
+    );
+});

--- a/packages/react-chain-of-responsibility/src/preview/tests/stability.changeProps.test.tsx
+++ b/packages/react-chain-of-responsibility/src/preview/tests/stability.changeProps.test.tsx
@@ -15,17 +15,19 @@ scenario('stability test with changing props', bdd => {
     .given('a TestComponent using chain of responsiblity', () => {
       const { Provider, reactComponent, useBuildRenderCallback } = createChainOfResponsibility<Request, Props>();
 
+      let count = 0;
       const renderCall = jest.fn();
 
-      const MyComponent = memo(function MyComponent(_: Props & { readonly dummy: string }) {
+      const MyComponent = memo(function MyComponent({ value }: Props & { readonly value: number }) {
         renderCall();
 
-        return <Fragment>Hello, World!</Fragment>;
+        return <Fragment>Hello, World! ({value})</Fragment>;
       });
 
       const middleware: readonly InferMiddleware<typeof Provider>[] = [
-        // With a changing props, the <MyComponent> should be re-rendered.
-        () => () => () => reactComponent(MyComponent, () => ({ dummy: crypto.randomUUID() }))
+        // Bind props change every time it is called.
+        // With a changing props, the <MyComponent> should always be re-rendered.
+        () => () => () => reactComponent(MyComponent, () => ({ value: ++count }))
       ];
 
       function MyProxy({ request }: { readonly request: number }) {
@@ -46,19 +48,26 @@ scenario('stability test with changing props', bdd => {
         renderCall
       ] as const;
     })
+
+    // ---
+
     .when('the component is rendered', ([TestComponent]) => render(<TestComponent request={1} />))
     .then('textContent should match', (_, { container }) =>
-      expect(container).toHaveProperty('textContent', 'Hello, World!')
+      expect(container).toHaveProperty('textContent', 'Hello, World! (1)')
     )
     .and('should have been rendered once', ([_, renderCall]) => expect(renderCall).toHaveBeenCalledTimes(1))
-    .when('the component is re-rendered with a different request', ([TestComponent], result) => {
-      // With same request, it should still re-render because props changed.
+
+    // ---
+
+    .when('the component is re-rendered with same request', ([TestComponent], result) => {
+      // With same request, it should still call enhancer because props could be changed.
       result.rerender(<TestComponent request={1} />);
 
       return result;
     })
     .then('textContent should match', (_, { container }) =>
-      expect(container).toHaveProperty('textContent', 'Hello, World!')
+      expect(container).toHaveProperty('textContent', 'Hello, World! (2)')
     )
+    // Because bindProps is a side-effect (change every time it is called), thus, the component must be rendered again.
     .and('should have been rendered twice', ([_, renderCall]) => expect(renderCall).toHaveBeenCalledTimes(2));
 });


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Changed

- (Preview) 💢 Changed signature to return wrapped return value, instead of plain `ComponentType`, by [@compulim](https://github.com/compulim) in PR [#91](https://github.com/compulim/react-chain-of-responsibility/pull/91), [#92](https://github.com/compulim/react-chain-of-responsibility/pull/92), [#99](https://github.com/compulim/react-chain-of-responsibility/pull/99), and [#100](https://github.com/compulim/react-chain-of-responsibility/pull/100)

## Specific changes

> Please list each individual specific change in this pull request.

- Side effect `bindProps` such as `() => ({ value: Math.random() })` should have their underlying component re-rendered as needed, removing `memo()` from `>Proxy>` and `useBuildRenderCallback()`