### PR TITLE
Add wrapper component to `reactComponent()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- (Preview) 💢 Changed signature to return wrapped return value, instead of plain `ComponentType`, by [@compulim](https://github.com/compulim) in PR [#91](https://github.com/compulim/react-chain-of-responsibility/pull/91), [#92](https://github.com/compulim/react-chain-of-responsibility/pull/92), [#99](https://github.com/compulim/react-chain-of-responsibility/pull/99), [#100](https://github.com/compulim/react-chain-of-responsibility/pull/100), [#101](https://github.com/compulim/react-chain-of-responsibility/pull/101), and [#104](https://github.com/compulim/react-chain-of-responsibility/pull/104)
+- (Preview) 💢 Changed signature to return wrapped return value, instead of plain `ComponentType`, by [@compulim](https://github.com/compulim) in PR [#91](https://github.com/compulim/react-chain-of-responsibility/pull/91), [#92](https://github.com/compulim/react-chain-of-responsibility/pull/92), [#99](https://github.com/compulim/react-chain-of-responsibility/pull/99), [#100](https://github.com/compulim/react-chain-of-responsibility/pull/100), [#101](https://github.com/compulim/react-chain-of-responsibility/pull/101)
+  - Fixed `reactComponent()` to return as `ReactElement` [#104](https://github.com/compulim/react-chain-of-responsibility/pull/104)
+  - Added wrapper component for `reactComponent()`, in PR [#105](https://github.com/compulim/react-chain-of-responsibility/pull/105)
 - Use `handler-chain` package, by [@compulim](https://github.com/compulim) in PR [#93](https://github.com/compulim/react-chain-of-responsibility/pull/93)
 - Bumped dependencies, in PR [#97](https://github.com/compulim/react-chain-of-responsibility/pull/97)
   - Development dependencies
@@ -39,8 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - 💢 `createChainOfResponsibilityForFluentUI` is marked as deprecated and will be removed in future releases, by [@compulim](https://github.com/compulim) in PR [#90](https://github.com/compulim/react-chain-of-responsibility/pull/90)
-   - Fluent UI v9 no longer use `IRenderFunction` for custom render
-   - The correctness of `createChainOfResponsibilityForFluentUI` is no longer validated
+  - Fluent UI v9 no longer use `IRenderFunction` for custom render
+  - The correctness of `createChainOfResponsibilityForFluentUI` is no longer validated
 
 ## [0.3.0] - 2025-06-22
 
@@ -85,7 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support nested provider of same type, by [@compulim](https://github.com/compulim) in PR [#64](https://github.com/compulim/react-chain-of-responsibility/pull/64)
-   - Components will be built using middleware from `<Provider>` closer to the `<Proxy>` and fallback to those farther away
+  - Components will be built using middleware from `<Provider>` closer to the `<Proxy>` and fallback to those farther away
 - Support `<Provider>`-less usage if `fallbackComponent` is specified, by [@compulim](https://github.com/compulim) in PR [#65](https://github.com/compulim/react-chain-of-responsibility/pull/65)
 - Support omitting `init` or `request` props in `<Provider>` and `<Proxy>` if they are of type `void`, by [@compulim](https://github.com/compulim) in PR [#66](https://github.com/compulim/react-chain-of-responsibility/pull/66)
 
@@ -94,33 +96,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 💢 Moved build tools from Babel to tsup/esbuild
 - 💢 Outside of `<Provider>`, when `useBuildComponentCallback` and `<Proxy>` is used with `fallbackComponent`, they will render the fallback component and no longer throwing exception
 - Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#49](https://github.com/compulim/react-chain-of-responsibility/pull/49), [#58](https://github.com/compulim/react-chain-of-responsibility/pull/58), [#63](https://github.com/compulim/react-chain-of-responsibility/pull/63), and [#67](https://github.com/compulim/react-chain-of-responsibility/pull/67)
-   - Production dependencies
-      - [`@babel/runtime-corejs3@7.24.6`](https://npmjs.com/package/@babel/runtime-corejs3)
-   - Development dependencies
-      - [`@babel/cli@7.24.6`](https://npmjs.com/package/@babel/cli)
-      - [`@babel/core@7.24.6`](https://npmjs.com/package/@babel/core/v/7.24.6)
-      - [`@babel/plugin-transform-runtime@7.24.6`](https://npmjs.com/package/@babel/plugin-transform-runtime)
-      - [`@babel/preset-env@7.24.7`](https://npmjs.com/package/@babel/preset-env/v/7.24.7)
-      - [`@babel/preset-react@7.24.7`](https://npmjs.com/package/@babel/preset-react/v/7.24.7)
-      - [`@babel/preset-typescript@7.24.7`](https://npmjs.com/package/@babel/preset-typescript/v/7.24.7)
-      - [`@fluentui/react@8.119.0`](https://npmjs.com/package/@fluentui/react/v/8.119.0)
-      - [`@testing-library/dom@10.2.0`](https://npmjs.com/package/@testing-library/dom/v/10.2.0)
-      - [`@testing-library/react@16.0.0`](https://npmjs.com/package/@testing-library/react/v/16.0.0)
-      - [`@tsconfig/recommended@1.0.6`](https://npmjs.com/package/@tsconfig/recommended)
-      - [`@tsconfig/strictest@2.0.5`](https://npmjs.com/package/@tsconfig/strictest/v/2.0.5)
-      - [`@types/jest@29.5.12`](https://npmjs.com/package/@types/jest/v/29.5.12)
-      - [`@types/node@20.14.9`](https://npmjs.com/package/@types/node/v/20.14.9)
-      - [`@types/react-dom@18.3.0`](https://npmjs.com/package/@types/react-dom/v/18.3.0)
-      - [`@types/react@18.3.3`](https://npmjs.com/package/@types/react/v/18.3.3)
-      - [`esbuild@0.21.5`](https://npmjs.com/package/esbuild/v/0.21.5)
-      - [`jest-environment-jsdom@29.7.0`](https://npmjs.com/package/jest-environment-jsdom/v/29.7.0)
-      - [`jest@29.7.0`](https://npmjs.com/package/jest/v/29.7.0)
-      - [`prettier@3.3.2`](https://npmjs.com/package/prettier/v/3.3.2)
-      - [`react-dom@18.3.1`](https://npmjs.com/package/react-dom/v/18.3.1)
-      - [`react-test-renderer@18.3.1`](https://npmjs.com/package/react-test-renderer/v/18.3.1)
-      - [`react@18.3.1`](https://npmjs.com/package/react/v/18.3.1)
-      - [`tsup@8.1.0`](https://npmjs.com/package/tsup/v/8.1.0)
-      - [`typescript@5.5.2`](https://npmjs.com/package/typescript/v/5.5.2)
+  - Production dependencies
+    - [`@babel/runtime-corejs3@7.24.6`](https://npmjs.com/package/@babel/runtime-corejs3)
+  - Development dependencies
+    - [`@babel/cli@7.24.6`](https://npmjs.com/package/@babel/cli)
+    - [`@babel/core@7.24.6`](https://npmjs.com/package/@babel/core/v/7.24.6)
+    - [`@babel/plugin-transform-runtime@7.24.6`](https://npmjs.com/package/@babel/plugin-transform-runtime)
+    - [`@babel/preset-env@7.24.7`](https://npmjs.com/package/@babel/preset-env/v/7.24.7)
+    - [`@babel/preset-react@7.24.7`](https://npmjs.com/package/@babel/preset-react/v/7.24.7)
+    - [`@babel/preset-typescript@7.24.7`](https://npmjs.com/package/@babel/preset-typescript/v/7.24.7)
+    - [`@fluentui/react@8.119.0`](https://npmjs.com/package/@fluentui/react/v/8.119.0)
+    - [`@testing-library/dom@10.2.0`](https://npmjs.com/package/@testing-library/dom/v/10.2.0)
+    - [`@testing-library/react@16.0.0`](https://npmjs.com/package/@testing-library/react/v/16.0.0)
+    - [`@tsconfig/recommended@1.0.6`](https://npmjs.com/package/@tsconfig/recommended)
+    - [`@tsconfig/strictest@2.0.5`](https://npmjs.com/package/@tsconfig/strictest/v/2.0.5)
+    - [`@types/jest@29.5.12`](https://npmjs.com/package/@types/jest/v/29.5.12)
+    - [`@types/node@20.14.9`](https://npmjs.com/package/@types/node/v/20.14.9)
+    - [`@types/react-dom@18.3.0`](https://npmjs.com/package/@types/react-dom/v/18.3.0)
+    - [`@types/react@18.3.3`](https://npmjs.com/package/@types/react/v/18.3.3)
+    - [`esbuild@0.21.5`](https://npmjs.com/package/esbuild/v/0.21.5)
+    - [`jest-environment-jsdom@29.7.0`](https://npmjs.com/package/jest-environment-jsdom/v/29.7.0)
+    - [`jest@29.7.0`](https://npmjs.com/package/jest/v/29.7.0)
+    - [`prettier@3.3.2`](https://npmjs.com/package/prettier/v/3.3.2)
+    - [`react-dom@18.3.1`](https://npmjs.com/package/react-dom/v/18.3.1)
+    - [`react-test-renderer@18.3.1`](https://npmjs.com/package/react-test-renderer/v/18.3.1)
+    - [`react@18.3.1`](https://npmjs.com/package/react/v/18.3.1)
+    - [`tsup@8.1.0`](https://npmjs.com/package/tsup/v/8.1.0)
+    - [`typescript@5.5.2`](https://npmjs.com/package/typescript/v/5.5.2)
 - Added [ESLint import/export syntax](https://npmjs.com/package/eslint-plugin-import), in PR [#68](https://github.com/compulim/react-chain-of-responsibility/pull/68)
 - Added [`publint`](https://npmjs.com/package/publint), in PR [#68](https://github.com/compulim/react-chain-of-responsibility/pull/68)
 - Bumped dependencies, in PR [#70](https://github.com/compulim/react-chain-of-responsibility/pull/70)
@@ -149,8 +151,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - 💢 Removed named exports, please import the defaults instead
-   - Use `import { createChainOfResponsibility } from 'react-chain-of-responsibility'` instead
-   - `import { createChainOfResponsibilityForFluentUI } from 'react-chain-of-responsibility/fluentUI'` for Fluent UI renderer function
+  - Use `import { createChainOfResponsibility } from 'react-chain-of-responsibility'` instead
+  - `import { createChainOfResponsibilityForFluentUI } from 'react-chain-of-responsibility/fluentUI'` for Fluent UI renderer function
 
 ## [0.1.0] - 2024-04-01
 
@@ -158,34 +160,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Relaxed peer dependencies requirements to `react@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#45](https://github.com/compulim/react-chain-of-responsibility/pull/45)
 - Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#42](https://github.com/compulim/react-chain-of-responsibility/pull/42), [#43](https://github.com/compulim/react-chain-of-responsibility/pull/43), and [#45](https://github.com/compulim/react-chain-of-responsibility/pull/45)
-   - Production dependencies
-      - [`@babel/runtime-corejs3@7.24.1`](https://npmjs.com/package/@babel/runtime-corejs3)
-   - Development dependencies
-      - [`@babel/cli@7.24.1`](https://npmjs.com/package/@babel/cli)
-      - [`@babel/core@7.24.3`](https://npmjs.com/package/@babel/core)
-      - [`@babel/plugin-transform-runtime@7.24.3`](https://npmjs.com/package/@babel/plugin-transform-runtime)
-      - [`@babel/preset-env@7.24.3`](https://npmjs.com/package/@babel/preset-env)
-      - [`@babel/preset-react@7.24.1`](https://npmjs.com/package/@babel/preset-react)
-      - [`@babel/preset-typescript@7.24.1`](https://npmjs.com/package/@babel/preset-typescript)
-      - [`@fluentui/react@8.117.0`](https://npmjs.com/package/@fluentui/react)
-      - [`@testing-library/react@14.2.2`](https://npmjs.com/package/@testing-library/react)
-      - [`@tsconfig/recommended@1.0.4`](https://npmjs.com/package/@tsconfig/recommended)
-      - [`@tsconfig/strictest@2.0.4`](https://npmjs.com/package/@tsconfig/strictest)
-      - [`@types/jest@29.5.12`](https://npmjs.com/package/@types/jest)
-      - [`@types/node@20.11.30`](https://npmjs.com/package/@types/node)
-      - [`@types/react@18.2.70`](https://npmjs.com/package/@types/react)
-      - [`@typescript-eslint/eslint-plugin@7.4.0`](https://npmjs.com/package/@typescript-eslint/eslint-plugin)
-      - [`@typescript-eslint/parser@7.4.0`](https://npmjs.com/package/@typescript-eslint/parser)
-      - [`esbuild@0.20.2`](https://npmjs.com/package/esbuild)
-      - [`eslint-plugin-prettier@5.1.3`](https://npmjs.com/package/eslint-plugin-prettier)
-      - [`eslint-plugin-react@7.34.1`](https://npmjs.com/package/eslint-plugin-react)
-      - [`eslint@8.57.0`](https://npmjs.com/package/eslint)
-      - [`prettier@3.2.5`](https://npmjs.com/package/prettier)
-      - [`react-wrap-with@0.1.0`](https://npmjs.com/package/react-wrap-with)
-      - [`typescript@5.4.3`](https://npmjs.com/package/typescript)
+  - Production dependencies
+    - [`@babel/runtime-corejs3@7.24.1`](https://npmjs.com/package/@babel/runtime-corejs3)
+  - Development dependencies
+    - [`@babel/cli@7.24.1`](https://npmjs.com/package/@babel/cli)
+    - [`@babel/core@7.24.3`](https://npmjs.com/package/@babel/core)
+    - [`@babel/plugin-transform-runtime@7.24.3`](https://npmjs.com/package/@babel/plugin-transform-runtime)
+    - [`@babel/preset-env@7.24.3`](https://npmjs.com/package/@babel/preset-env)
+    - [`@babel/preset-react@7.24.1`](https://npmjs.com/package/@babel/preset-react)
+    - [`@babel/preset-typescript@7.24.1`](https://npmjs.com/package/@babel/preset-typescript)
+    - [`@fluentui/react@8.117.0`](https://npmjs.com/package/@fluentui/react)
+    - [`@testing-library/react@14.2.2`](https://npmjs.com/package/@testing-library/react)
+    - [`@tsconfig/recommended@1.0.4`](https://npmjs.com/package/@tsconfig/recommended)
+    - [`@tsconfig/strictest@2.0.4`](https://npmjs.com/package/@tsconfig/strictest)
+    - [`@types/jest@29.5.12`](https://npmjs.com/package/@types/jest)
+    - [`@types/node@20.11.30`](https://npmjs.com/package/@types/node)
+    - [`@types/react@18.2.70`](https://npmjs.com/package/@types/react)
+    - [`@typescript-eslint/eslint-plugin@7.4.0`](https://npmjs.com/package/@typescript-eslint/eslint-plugin)
+    - [`@typescript-eslint/parser@7.4.0`](https://npmjs.com/package/@typescript-eslint/parser)
+    - [`esbuild@0.20.2`](https://npmjs.com/package/esbuild)
+    - [`eslint-plugin-prettier@5.1.3`](https://npmjs.com/package/eslint-plugin-prettier)
+    - [`eslint-plugin-react@7.34.1`](https://npmjs.com/package/eslint-plugin-react)
+    - [`eslint@8.57.0`](https://npmjs.com/package/eslint)
+    - [`prettier@3.2.5`](https://npmjs.com/package/prettier)
+    - [`react-wrap-with@0.1.0`](https://npmjs.com/package/react-wrap-with)
+    - [`typescript@5.4.3`](https://npmjs.com/package/typescript)
 - Updated pull request validation to test against various React versions, in PR [#44](https://github.com/compulim/react-chain-of-responsibility/pull/44)
-   - Moved from JSX Runtime to JSX Classic to support testing against React 16
-   - Added NPM scripts `switch:react:*` to provide a one-way door to switch to a specific React version for testing purpose
+  - Moved from JSX Runtime to JSX Classic to support testing against React 16
+  - Added NPM scripts `switch:react:*` to provide a one-way door to switch to a specific React version for testing purpose
 
 ## [0.0.2] - 2023-10-09
 
@@ -194,29 +196,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added type-checking for test, by [@compulim](https://github.com/compulim), in PR [#20](https://github.com/compulim/react-chain-of-responsibility/pull/20)
 - Updates `tsconfig.json` to extend from [`@tsconfig/strictest`](https://npmjs.com/package/@tsconfig/strictest), by [@compulim](https://github.com/compulim), in PR [#20](https://github.com/compulim/react-chain-of-responsibility/pull/20)
 - Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#24](https://github.com/compulim/react-chain-of-responsibility/pull/24), and PR [#36](https://github.com/compulim/react-chain-of-responsibility/pull/36)
-   - Production dependencies
-      - [`@babel/runtime-corejs3@7.23.1`](https://npmjs.com/package/@babel/runtime-corejs3)
-   - Development dependencies
-      - [`@babel/cli@7.23.0`](https://npmjs.com/package/@babel/cli)
-      - [`@babel/core@7.23.0`](https://npmjs.com/package/@babel/core)
-      - [`@babel/preset-env@7.22.20`](https://npmjs.com/package/@babel/preset-env)
-      - [`@babel/preset-typescript@7.23.0`](https://npmjs.com/package/@babel/preset-typescript)
-      - [`@fluentui/react@8.112.2`](https://npmjs.com/package/@fluentui/react)
-      - [`@testing-library/react@14.0.0`](https://npmjs.com/package/@testing-library/react)
-      - [`@tsconfig/recommended@1.0.3`](https://npmjs.com/package/@tsconfig/recommended)
-      - [`@types/jest@29.5.5`](https://npmjs.com/package/@types/jest)
-      - [`@types/node@20.8.3`](https://npmjs.com/package/@types/node)
-      - [`@types/react@18.2.25`](https://npmjs.com/package/@types/react)
-      - [`@typescript-eslint/eslint-plugin@6.7.4`](https://npmjs.com/package/@typescript-eslint/eslint-plugin)
-      - [`@typescript-eslint/parser@6.7.4`](https://npmjs.com/package/@typescript-eslint/parser)
-      - [`esbuild@0.19.4`](https://npmjs.com/package/esbuild)
-      - [`eslint@8.51.0`](https://npmjs.com/package/eslint)
-      - [`jest-environment-jsdom@29.7.0`](https://npmjs.com/package/jest-environment-jsdom)
-      - [`jest@29.7.0`](https://npmjs.com/package/jest)
-      - [`react-dom@18.2.0`](https://npmjs.com/package/react-dom)
-      - [`react-test-renderer@18.2.0`](https://npmjs.com/package/react-test-renderer)
-      - [`react-wrap-with@0.0.4`](https://npmjs.com/package/react-wrap-with)
-      - [`react@18.2.0`](https://npmjs.com/package/react)
+  - Production dependencies
+    - [`@babel/runtime-corejs3@7.23.1`](https://npmjs.com/package/@babel/runtime-corejs3)
+  - Development dependencies
+    - [`@babel/cli@7.23.0`](https://npmjs.com/package/@babel/cli)
+    - [`@babel/core@7.23.0`](https://npmjs.com/package/@babel/core)
+    - [`@babel/preset-env@7.22.20`](https://npmjs.com/package/@babel/preset-env)
+    - [`@babel/preset-typescript@7.23.0`](https://npmjs.com/package/@babel/preset-typescript)
+    - [`@fluentui/react@8.112.2`](https://npmjs.com/package/@fluentui/react)
+    - [`@testing-library/react@14.0.0`](https://npmjs.com/package/@testing-library/react)
+    - [`@tsconfig/recommended@1.0.3`](https://npmjs.com/package/@tsconfig/recommended)
+    - [`@types/jest@29.5.5`](https://npmjs.com/package/@types/jest)
+    - [`@types/node@20.8.3`](https://npmjs.com/package/@types/node)
+    - [`@types/react@18.2.25`](https://npmjs.com/package/@types/react)
+    - [`@typescript-eslint/eslint-plugin@6.7.4`](https://npmjs.com/package/@typescript-eslint/eslint-plugin)
+    - [`@typescript-eslint/parser@6.7.4`](https://npmjs.com/package/@typescript-eslint/parser)
+    - [`esbuild@0.19.4`](https://npmjs.com/package/esbuild)
+    - [`eslint@8.51.0`](https://npmjs.com/package/eslint)
+    - [`jest-environment-jsdom@29.7.0`](https://npmjs.com/package/jest-environment-jsdom)
+    - [`jest@29.7.0`](https://npmjs.com/package/jest)
+    - [`react-dom@18.2.0`](https://npmjs.com/package/react-dom)
+    - [`react-test-renderer@18.2.0`](https://npmjs.com/package/react-test-renderer)
+    - [`react-wrap-with@0.0.4`](https://npmjs.com/package/react-wrap-with)
+    - [`react@18.2.0`](https://npmjs.com/package/react)
 
 ### Fixed
 
@@ -233,24 +235,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#1](https://github.com/compulim/react-chain-of-responsibility/pull/1)
-   -  Production dependencies
-      -  [`@babel/runtime-corejs3@7.21.0`](https://npmjs.com/package/@babel/runtime-corejs3)
-   -  Development dependencies
-      -  [`@babel/cli@7.21.0`](https://npmjs.com/package/@babel/cli)
-      -  [`@babel/core@7.21.0`](https://npmjs.com/package/@babel/core)
-      -  [`@babel/plugin-transform-runtime@7.21.0`](https://npmjs.com/package/@babel/plugin-transform-runtime)
-      -  [`@babel/preset-typescript@7.21.0`](https://npmjs.com/package/@babel/preset-typescript)
-      -  [`@types/node@18.14.0`](https://npmjs.com/package/@types/node)
-      -  [`@types/react@17.0.53`](https://npmjs.com/package/@types/react)
-      -  [`@typescript-eslint/eslint-plugin@5.53.0`](https://npmjs.com/package/@typescript-eslint/eslint-plugin)
-      -  [`@typescript-eslint/parser@5.53.0`](https://npmjs.com/package/@typescript-eslint/parser)
-      -  [`esbuild@0.17.10`](https://npmjs.com/package/esbuild)
-      -  [`eslint-plugin-react@7.32.2`](https://npmjs.com/package/eslint-plugin-react)
-      -  [`eslint@8.34.0`](https://npmjs.com/package/eslint)
-      -  [`jest-environment-jsdom@29.4.3`](https://npmjs.com/package/jest-environment-jsdom)
-      -  [`jest@29.4.3`](https://npmjs.com/package/jest)
-      -  [`prettier@2.8.4`](https://npmjs.com/package/prettier)
-      -  [`typescript@4.9.5`](https://npmjs.com/package/typescript)
+  - Production dependencies
+    - [`@babel/runtime-corejs3@7.21.0`](https://npmjs.com/package/@babel/runtime-corejs3)
+  - Development dependencies
+    - [`@babel/cli@7.21.0`](https://npmjs.com/package/@babel/cli)
+    - [`@babel/core@7.21.0`](https://npmjs.com/package/@babel/core)
+    - [`@babel/plugin-transform-runtime@7.21.0`](https://npmjs.com/package/@babel/plugin-transform-runtime)
+    - [`@babel/preset-typescript@7.21.0`](https://npmjs.com/package/@babel/preset-typescript)
+    - [`@types/node@18.14.0`](https://npmjs.com/package/@types/node)
+    - [`@types/react@17.0.53`](https://npmjs.com/package/@types/react)
+    - [`@typescript-eslint/eslint-plugin@5.53.0`](https://npmjs.com/package/@typescript-eslint/eslint-plugin)
+    - [`@typescript-eslint/parser@5.53.0`](https://npmjs.com/package/@typescript-eslint/parser)
+    - [`esbuild@0.17.10`](https://npmjs.com/package/esbuild)
+    - [`eslint-plugin-react@7.32.2`](https://npmjs.com/package/eslint-plugin-react)
+    - [`eslint@8.34.0`](https://npmjs.com/package/eslint)
+    - [`jest-environment-jsdom@29.4.3`](https://npmjs.com/package/jest-environment-jsdom)
+    - [`jest@29.4.3`](https://npmjs.com/package/jest)
+    - [`prettier@2.8.4`](https://npmjs.com/package/prettier)
+    - [`typescript@4.9.5`](https://npmjs.com/package/typescript)
 
 [Unreleased]: https://github.com/compulim/react-chain-of-responsibility/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/compulim/react-chain-of-responsibility/compare/v0.2.0...v0.3.0

--- a/packages/integration-test/package.json
+++ b/packages/integration-test/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "private": true,
   "scripts": {
-    "build": "if test \"$CI\" = \"true\"; then mkdir -p ./test/webDriver/static/js/; cp `node --eval=\"console.log(require('path').resolve(require('resolve-cwd')('@testduet/wait-for'), '../../dist/**'))\"` ./test/webDriver/static/js/; else mkdir -p ./test/webDriver/static/; ln --relative --symbolic `node --eval=\"console.log(require('path').resolve(require('resolve-cwd')('@testduet/wait-for'), '../../dist'))\"` ./test/webDriver/static/js; fi",
+    "build": "if test \"$CI\" = \"true\"; then mkdir -p ./test/webDriver/static/js/; cp `node --eval=\"console.log(require('path').resolve(require('resolve-cwd')('@testduet/wait-for'), '../../dist/**'))\"` ./test/webDriver/static/js/; else mkdir -p ./test/webDriver/static/; ln --force --relative --symbolic `node --eval=\"console.log(require('path').resolve(require('resolve-cwd')('@testduet/wait-for'), '../../dist'))\"` ./test/webDriver/static/js; fi",
     "bump": "npm run bump:prod && npm run bump:dev",
     "bump:dev": "PACKAGES_TO_BUMP=$(cat package.json | jq -r '(.pinDependencies // {}) as $P | (.localPeerDependencies // {}) as $L | (.devDependencies // {}) | to_entries | map(select(.key as $K | $L | has($K) | not)) | map(.key + \"@\" + ($P[.key] // [\"latest\"])[0]) | join(\" \")') && [ ! -z \"$PACKAGES_TO_BUMP\" ] && npm install $PACKAGES_TO_BUMP || true",
     "bump:prod": "PACKAGES_TO_BUMP=$(cat package.json | jq -r '(.pinDependencies // {}) as $P | (.localPeerDependencies // {}) as $L | (.dependencies // {}) | to_entries | map(select(.key as $K | $L | has($K) | not)) | map(.key + \"@\" + ($P[.key] // [\"latest\"])[0]) | join(\" \")') && [ ! -z \"$PACKAGES_TO_BUMP\" ] && npm install $PACKAGES_TO_BUMP || true",

--- a/packages/react-chain-of-responsibility/src/preview/createChainOfResponsibilityAsRenderCallback.tsx
+++ b/packages/react-chain-of-responsibility/src/preview/createChainOfResponsibilityAsRenderCallback.tsx
@@ -201,7 +201,7 @@ function createChainOfResponsibility<
     // memo() and generic type do not play well together.
     const TypedWrapperComponent = WrapperComponent as ComponentType<WrapperComponentProps<P, W>>;
 
-    if (init?.wrapperComponent) {
+    if (init?.wrapperComponent && init.wrapperProps) {
       return createComponentHandlerResult((overridingProps?: Partial<Props> | undefined) => (
         <TypedWrapperComponent
           bindProps={bindProps}

--- a/packages/react-chain-of-responsibility/src/preview/tests/fallbackComponent.withPropsViaMiddleware.test.tsx
+++ b/packages/react-chain-of-responsibility/src/preview/tests/fallbackComponent.withPropsViaMiddleware.test.tsx
@@ -8,7 +8,6 @@ import React, { Fragment, type ReactNode } from 'react';
 import createChainOfResponsibility, { type InferMiddleware } from '../createChainOfResponsibilityAsRenderCallback';
 
 type Props = {
-  readonly children?: never;
   readonly value: number;
 };
 

--- a/packages/react-chain-of-responsibility/src/preview/tests/wrapper.overridePropsAndRequest.test.tsx
+++ b/packages/react-chain-of-responsibility/src/preview/tests/wrapper.overridePropsAndRequest.test.tsx
@@ -39,7 +39,7 @@ function Upstream({ result, value }: UpstreamProps): ReactElement | null {
 
 scenario('with wrapper component and overriding props and request', bdd => {
   bdd
-    .given('a TestComponent using chain of responsiblity', () => {
+    .given('a TestComponent using chain of responsibility', () => {
       const { Provider, Proxy, reactComponent } = createChainOfResponsibility<Request, Props>({
         allowOverrideProps: true,
         passModifiedRequest: true

--- a/packages/react-chain-of-responsibility/src/preview/tests/wrapper.overridePropsAndRequest.test.tsx
+++ b/packages/react-chain-of-responsibility/src/preview/tests/wrapper.overridePropsAndRequest.test.tsx
@@ -1,0 +1,72 @@
+/** @jest-environment jsdom */
+/// <reference types="@types/jest" />
+
+import { scenario } from '@testduet/given-when-then';
+import { render } from '@testing-library/react';
+import React, { Fragment, type ReactElement, type ReactNode } from 'react';
+
+import createChainOfResponsibility, {
+  type ComponentHandlerResult,
+  type InferMiddleware
+} from '../createChainOfResponsibilityAsRenderCallback';
+
+type Props = { readonly children?: never; readonly value: number };
+type Request = number;
+
+type MyWrapperProps = { readonly children?: ReactNode | undefined; readonly request: number };
+
+function MyWrapper({ children, request }: MyWrapperProps) {
+  return (
+    <Fragment>
+      {`<MyWrapper request={${request}}>`}
+      {children}
+      {'</MyWrapper>'}
+    </Fragment>
+  );
+}
+
+type MyComponentProps = Props & { readonly value: number };
+
+function MyComponent({ value }: MyComponentProps) {
+  return <Fragment>Hello, World! ({value})</Fragment>;
+}
+
+type UpstreamProps = Props & { readonly result: ComponentHandlerResult<Props> | undefined };
+
+function Upstream({ result, value }: UpstreamProps): ReactElement | null {
+  return <Fragment>{result?.render?.({ value: value + 1 })}</Fragment>;
+}
+
+scenario('with wrapper component and overriding props and request', bdd => {
+  bdd
+    .given('a TestComponent using chain of responsiblity', () => {
+      const { Provider, Proxy, reactComponent } = createChainOfResponsibility<Request, Props>({
+        allowOverrideProps: true,
+        passModifiedRequest: true
+      });
+
+      const middleware: readonly InferMiddleware<typeof Provider>[] = [
+        () => next => request => {
+          return reactComponent(
+            Upstream,
+            { result: next(request * 10) },
+            { wrapperComponent: Fragment, wrapperProps: {} }
+          );
+        },
+        () => () => request =>
+          reactComponent(MyComponent, {}, { wrapperComponent: MyWrapper, wrapperProps: { request } })
+      ];
+
+      return function TestComponent() {
+        return (
+          <Provider middleware={middleware}>
+            <Proxy request={1} value={1} />
+          </Provider>
+        );
+      };
+    })
+    .when('the component is rendered', TestComponent => render(<TestComponent />))
+    .then('textContent should match', (_, { container }) =>
+      expect(container).toHaveProperty('textContent', '<MyWrapper request={10}>Hello, World! (2)</MyWrapper>')
+    );
+});

--- a/packages/react-chain-of-responsibility/src/preview/tests/wrapper.test.tsx
+++ b/packages/react-chain-of-responsibility/src/preview/tests/wrapper.test.tsx
@@ -1,0 +1,53 @@
+/** @jest-environment jsdom */
+/// <reference types="@types/jest" />
+
+import { scenario } from '@testduet/given-when-then';
+import { render } from '@testing-library/react';
+import React, { Fragment, type ReactNode } from 'react';
+
+import createChainOfResponsibility, { type InferMiddleware } from '../createChainOfResponsibilityAsRenderCallback';
+
+type Props = { readonly children?: never; readonly value: number };
+type Request = number;
+
+type MyWrapperProps = { readonly children?: ReactNode | undefined; readonly request: number };
+
+function MyWrapper({ children, request }: MyWrapperProps) {
+  return (
+    <Fragment>
+      {`<MyWrapper request={${request}}>`}
+      {children}
+      {'</MyWrapper>'}
+    </Fragment>
+  );
+}
+
+type MyComponentProps = Props & { readonly value: number };
+
+function MyComponent({ value }: MyComponentProps) {
+  return <Fragment>Hello, World! ({value})</Fragment>;
+}
+
+scenario('with wrapper component', bdd => {
+  bdd
+    .given('a TestComponent using chain of responsiblity', () => {
+      const { Provider, Proxy, reactComponent } = createChainOfResponsibility<Request, Props>();
+
+      const middleware: readonly InferMiddleware<typeof Provider>[] = [
+        () => () => request =>
+          reactComponent(MyComponent, {}, { wrapperComponent: MyWrapper, wrapperProps: { request } })
+      ];
+
+      return function TestComponent() {
+        return (
+          <Provider middleware={middleware}>
+            <Proxy request={1} value={1} />
+          </Provider>
+        );
+      };
+    })
+    .when('the component is rendered', TestComponent => render(<TestComponent />))
+    .then('textContent should match', (_, { container }) =>
+      expect(container).toHaveProperty('textContent', '<MyWrapper request={1}>Hello, World! (1)</MyWrapper>')
+    );
+});

--- a/packages/react-chain-of-responsibility/src/preview/tests/wrapper.wrapperProps.function.test.tsx
+++ b/packages/react-chain-of-responsibility/src/preview/tests/wrapper.wrapperProps.function.test.tsx
@@ -1,0 +1,57 @@
+/** @jest-environment jsdom */
+/// <reference types="@types/jest" />
+
+import { scenario } from '@testduet/given-when-then';
+import { render } from '@testing-library/react';
+import React, { Fragment, type ReactNode } from 'react';
+
+import createChainOfResponsibility, { type InferMiddleware } from '../createChainOfResponsibilityAsRenderCallback';
+
+type Props = { readonly children?: never; readonly value: number };
+type Request = number;
+
+type MyWrapperProps = { readonly children?: ReactNode | undefined; readonly value: number };
+
+function MyWrapper({ children, value }: MyWrapperProps) {
+  return (
+    <Fragment>
+      {`<MyWrapper value={${value}}>`}
+      {children}
+      {'</MyWrapper>'}
+    </Fragment>
+  );
+}
+
+type MyComponentProps = Props & { readonly value: number };
+
+function MyComponent({ value }: MyComponentProps) {
+  return <Fragment>Hello, World! ({value})</Fragment>;
+}
+
+scenario('with wrapper component', bdd => {
+  bdd
+    .given('a TestComponent using chain of responsiblity', () => {
+      const { Provider, Proxy, reactComponent } = createChainOfResponsibility<Request, Props>();
+
+      const middleware: readonly InferMiddleware<typeof Provider>[] = [
+        () => () => request =>
+          reactComponent(
+            MyComponent,
+            {},
+            { wrapperComponent: MyWrapper, wrapperProps: props => ({ value: request + props.value }) }
+          )
+      ];
+
+      return function TestComponent() {
+        return (
+          <Provider middleware={middleware}>
+            <Proxy request={1} value={2} />
+          </Provider>
+        );
+      };
+    })
+    .when('the component is rendered', TestComponent => render(<TestComponent />))
+    .then('textContent should match', (_, { container }) =>
+      expect(container).toHaveProperty('textContent', '<MyWrapper value={3}>Hello, World! (2)</MyWrapper>')
+    );
+});

--- a/packages/react-chain-of-responsibility/src/preview/tests/wrapper.wrapperProps.function.test.tsx
+++ b/packages/react-chain-of-responsibility/src/preview/tests/wrapper.wrapperProps.function.test.tsx
@@ -30,7 +30,7 @@ function MyComponent({ value }: MyComponentProps) {
 
 scenario('with wrapper component', bdd => {
   bdd
-    .given('a TestComponent using chain of responsiblity', () => {
+    .given('a TestComponent using chain of responsibility', () => {
       const { Provider, Proxy, reactComponent } = createChainOfResponsibility<Request, Props>();
 
       const middleware: readonly InferMiddleware<typeof Provider>[] = [


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Added

- (Preview) 💢 Changed signature to return wrapped return value, instead of plain `ComponentType`, by [@compulim](https://github.com/compulim) in PR [#91](https://github.com/compulim/react-chain-of-responsibility/pull/91), [#92](https://github.com/compulim/react-chain-of-responsibility/pull/92), [#99](https://github.com/compulim/react-chain-of-responsibility/pull/99), [#100](https://github.com/compulim/react-chain-of-responsibility/pull/100), [#101](https://github.com/compulim/react-chain-of-responsibility/pull/101)
  - Fixed `reactComponent()` to return as `ReactElement` [#104](https://github.com/compulim/react-chain-of-responsibility/pull/104)
  - Added wrapper component for `reactComponent()`, in PR [#105](https://github.com/compulim/react-chain-of-responsibility/pull/105)

## Specific changes

> Please list each individual specific change in this pull request.

- Added `ReactComponentInit.wrapperComponent` and `wrapperProps` to `reactComponent()`
   - Wrapper component helps cleaner props separation, for example, passing hidden props to context (wrapper)